### PR TITLE
Update CI to create JPMS compatible versions

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -8,10 +8,10 @@ inputs:
 outputs:
   revision:
     description: 'The version as retrieved from the last tag + eventual updates since that tag'
-    value: ${{ steps.get-version.outputs.version }}
+    value: ${{ steps.get-version.outputs.revision }}
   sha1:
     description: 'The shortened sha1 hash of the commit'
-    value: ${{ steps.get-version.outputs.rev }}
+    value: ${{ steps.get-version.outputs.sha1 }}
   changelist:
     description: 'empty for releases, otherwise -SNAPSHOT'
     value: ${{ steps.get-version.outputs.changelist }}

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -36,13 +36,13 @@ runs:
           if [[ -z "$lasttag" ]]; then
             echo "[warning] Could not find last valid version number!"
             export lasttag=0.0.1
-            export newcomits=-0
+            export newcommits=-0
           else
             export tmp=${desc#"$lasttag"}
             export newcommits=${tmp%-*}
           fi
-          export rev=${lasttag}${branch}${newcommits}
-          export sha1=$(git rev-parse --short HEAD)
+          export rev=${lasttag}-${branch}${newcommits}
+          export sha1=-$(git rev-parse --short HEAD)
           export changelist="-SNAPSHOT"
         fi
         echo "::set-output name=revision::$(echo $rev)"

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -27,14 +27,20 @@ runs:
           export sha1=""
           export changelist=""
         else
-          export branch=${gh_rev/\//-}
+          export branch=${gh_ref/\//-}
           if [[ $branch =~ [1-9]*-merge ]]; then
             export branch=PR${branch%-merge}
           fi
           export lasttag=`git describe --tags --match=${{ inputs.versionPattern }} --abbrev=0`
           export desc=`git describe --tags --match=${{ inputs.versionPattern }} --long`
-          export tmp=${desc#"$lasttag"}
-          export newcommits=${tmp%-*}
+          if [[ -z "$lasttag" ]]; then
+            echo "[warning] Could not find last valid version number!"
+            export lasttag=0.0.1
+            export newcomits=-0
+          else
+            export tmp=${desc#"$lasttag"}
+            export newcommits=${tmp%-*}
+          fi
           export rev=${lasttag}${branch}${newcommits}
           export sha1=$(git rev-parse --short HEAD)
           export changelist="-SNAPSHOT"

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -18,28 +18,29 @@ outputs:
 runs:
   using: "composite"
   steps:
-    -id: get-version
-    -run: |
-      export gh_ref=${GITHUB_REF#refs/*/}
-      if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ inputs.versionPattern }}$ ]]; then
-        export revision=${gh_rev/\//-}
-        export sha1=""
-        export changelist=""
-      else
-        export branch=${gh_rev/\//-}
-        if [[ $branch =~ [1-9]*-merge ]]; then
-          export branch=PR${branch%-merge}
+    - id: get-version
+      shell: bash
+      run: |
+        export gh_ref=${GITHUB_REF#refs/*/}
+        if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ inputs.versionPattern }}$ ]]; then
+          export revision=${gh_rev/\//-}
+          export sha1=""
+          export changelist=""
+        else
+          export branch=${gh_rev/\//-}
+          if [[ $branch =~ [1-9]*-merge ]]; then
+            export branch=PR${branch%-merge}
+          fi
+          export lasttag=`git describe --tags --match=${{ inputs.versionPattern }} --abbrev=0`
+          export desc=`git describe --tags --match=${{ inputs.versionPattern }} --long`
+          export tmp=${desc#"$lasttag"}
+          export newcommits=${tmp%-*}
+          export rev=${lasttag}${branch}${newcommits}
+          export sha1=$(git rev-parse --short HEAD)
+          export changelist="-SNAPSHOT"
         fi
-        export lasttag=`git describe --tags --match=${{ inputs.versionPattern }} --abbrev=0`
-        export desc=`git describe --tags --match=${{ inputs.versionPattern }} --long`
-        export tmp=${desc#"$lasttag"}
-        export newcommits=${tmp%-*}
-        export rev=${lasttag}${branch}${newcommits}
-        export sha1=$(git rev-parse --short HEAD)
-        export changelist="-SNAPSHOT"
-      fi
-      echo "::set-output name=revision::$(echo $rev)"
-      echo "::set-output name=sha1::$(echo $sha1)"
-      echo "::set-output name=changelist::$(echo $changelist)"
-      echo "Version will be:"
-      echo ${ver}${rev}${changelist}
+        echo "::set-output name=revision::$(echo $rev)"
+        echo "::set-output name=sha1::$(echo $sha1)"
+        echo "::set-output name=changelist::$(echo $changelist)"
+        echo "Version will be:"
+        echo ${ver}${rev}${changelist}

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -21,12 +21,15 @@ runs:
     -id: get-version
     -run: |
       export gh_ref=${GITHUB_REF#refs/*/}
-      if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ env.JAVA_REFERENCE_VERSION }}\.[0-9]*\.[0-9]*$ ]]; then
+      if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ inputs.versionPattern }}$ ]]; then
         export revision=${gh_rev/\//-}
         export sha1=""
         export changelist=""
       else
         export branch=${gh_rev/\//-}
+        if [[ $branch =~ [1-9]*-merge ]]; then
+          export branch=PR${branch%-merge}
+        fi
         export lasttag=`git describe --tags --match=${{ inputs.versionPattern }} --abbrev=0`
         export desc=`git describe --tags --match=${{ inputs.versionPattern }} --long`
         export tmp=${desc#"$lasttag"}

--- a/.github/actions/getVersion.yml
+++ b/.github/actions/getVersion.yml
@@ -1,0 +1,42 @@
+name: 'Get Version'
+description: 'Get version/rev/changelist from github rev and git describe'
+inputs:
+  versionPattern:
+    description: 'glob pattern to recognize valid version tags'
+    required: false
+    default: '[0-9]*.[0-9].[0-9]'
+outputs:
+  revision:
+    description: 'The version as retrieved from the last tag + eventual updates since that tag'
+    value: ${{ steps.get-version.outputs.version }}
+  sha1:
+    description: 'The shortened sha1 hash of the commit'
+    value: ${{ steps.get-version.outputs.rev }}
+  changelist:
+    description: 'empty for releases, otherwise -SNAPSHOT'
+    value: ${{ steps.get-version.outputs.changelist }}
+runs:
+  using: "composite"
+  steps:
+    -id: get-version
+    -run: |
+      export gh_ref=${GITHUB_REF#refs/*/}
+      if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ env.JAVA_REFERENCE_VERSION }}\.[0-9]*\.[0-9]*$ ]]; then
+        export revision=${gh_rev/\//-}
+        export sha1=""
+        export changelist=""
+      else
+        export branch=${gh_rev/\//-}
+        export lasttag=`git describe --tags --match=${{ inputs.versionPattern }} --abbrev=0`
+        export desc=`git describe --tags --match=${{ inputs.versionPattern }} --long`
+        export tmp=${desc#"$lasttag"}
+        export newcommits=${tmp%-*}
+        export rev=${lasttag}${branch}${newcommits}
+        export sha1=$(git rev-parse --short HEAD)
+        export changelist="-SNAPSHOT"
+      fi
+      echo "::set-output name=revision::$(echo $rev)"
+      echo "::set-output name=sha1::$(echo $sha1)"
+      echo "::set-output name=changelist::$(echo $changelist)"
+      echo "Version will be:"
+      echo ${ver}${rev}${changelist}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 100
     - id: version
-      uses: ./.github/actions/getVersion
+      uses: ./.github/actions/get-version
       with:
         versionPattern: '11.[0-9]*.[0-9]*'
     - uses: actions/cache@v1 # cache maven packages to speed up build
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: version
-        uses: ./.github/actions/getVersion
+        uses: ./.github/actions/get-version
         with:
           versionPattern: '11.[0-9]*.[0-9]*'
       - name: Cache the Maven packages to speed up build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,19 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 25
-    - name: Set version environment for version string
-      run: |
-        export REV=${GITHUB_REF#refs/*/}
-        echo "REVISION=${REV/\//-}" >> $GITHUB_ENV
-        if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ env.JAVA_REFERENCE_VERSION }}\.[0-9]*\.[0-9]*$ ]]; then
-          echo "CHANGELIST=" >> $GITHUB_ENV
-        else
-          echo "CHANGELIST=-SNAPSHOT" >> $GITHUB_ENV
-        fi
-        echo "github ref: ${GITHUB_REF}"
-        echo "setting env:"
-        cat ${GITHUB_ENV}
+        fetch-depth: 100
+    - id: version
+      uses: ./.github/actions/getVersion
+      with:
+        versionPattern: '11.[0-9]*.[0-9]*'
     - uses: actions/cache@v1 # cache maven packages to speed up build
       with:
         path: ~/.m2
@@ -49,7 +41,11 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - name: Test with Maven
-      run: mvn -Dgpg.skip=true --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dchangelist=${CHANGELIST} package
+      run: mvn -Dgpg.skip=true --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} package
+      env:
+        REVISION: ${{ steps.version.outputs.revision }}
+        SHA1: ${{ steps.version.outputs.sha1 }}
+        CHANGELIST: ${{ steps.version.outputs.changelist }}
     - name: coverage report - send to Codecov
       if: matrix.java == env.JAVA_REFERENCE_VERSION
       uses: codecov/codecov-action@v1.2.1
@@ -66,18 +62,10 @@ jobs:
     environment: deploy
     steps:
       - uses: actions/checkout@v2
-      - name: Set version environment for version string
-        run: |
-          export REV=${GITHUB_REF#refs/*/}
-          echo "REVISION=${REV/\//-}" >> $GITHUB_ENV
-          if [[ "${GITHUB_REF#refs/tags/}" =~ ^${{ env.JAVA_REFERENCE_VERSION }}\.[0-9]*\.[0-9]*$ ]]; then
-            echo "CHANGELIST=" >> $GITHUB_ENV
-          else
-            echo "CHANGELIST=-SNAPSHOT" >> $GITHUB_ENV
-          fi
-          echo "github ref: ${GITHUB_REF}"
-          echo "setting env:"
-          cat ${GITHUB_ENV}
+      - id: version
+        uses: ./.github/actions/getVersion
+        with:
+          versionPattern: '11.[0-9]*.[0-9]*'
       - name: Cache the Maven packages to speed up build
         uses: actions/cache@v1
         with:
@@ -91,10 +79,13 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: GPG_PASS
       - name: Deploy to Github Packages
-        run: if [ -z "$CHANGELIST" ]; then mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dchangelist=${CHANGELIST} -Drelease=github deploy; fi
+        run: if [ -z "$CHANGELIST" ]; then mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} -Drelease=github deploy; fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}
+          REVISION: ${{ steps.version.outputs.revision }}
+          SHA1: ${{ steps.version.outputs.sha1 }}
+          CHANGELIST: ${{ steps.version.outputs.changelist }}
       - name: Set up JDK to publish to OSSRH
         uses: actions/setup-java@v1.4.3
         with:
@@ -105,10 +96,13 @@ jobs:
           # gpg-private-key: ${{ secrets.GPG_KEY }} # gpg key was already added in the first java-setup phase, will fail the cleanup if added again
           gpg-passphrase: GPG_PASS
       - name: Deploy to Maven Central
-        run: mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dchangelist=${CHANGELIST} -Drelease=ossrh deploy
+        run: mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} -Drelease=ossrh deploy
         env:
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
+          REVISION: ${{ steps.version.outputs.revision }}
+          SHA1: ${{ steps.version.outputs.sha1 }}
+          CHANGELIST: ${{ steps.version.outputs.changelist }}
 
 ...

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
     - id: version
       uses: ./.github/actions/get-version
       with:
-        versionPattern: '11.[0-9]*.[0-9]*'
+          versionPattern: '${{ env.JAVA_REFERENCE_VERSION }}.[0-9]*.[0-9]*'
     - uses: actions/cache@v1 # cache maven packages to speed up build
       with:
         path: ~/.m2
@@ -65,7 +65,7 @@ jobs:
       - id: version
         uses: ./.github/actions/get-version
         with:
-          versionPattern: '11.[0-9]*.[0-9]*'
+          versionPattern: '${{ env.JAVA_REFERENCE_VERSION }}.[0-9]*.[0-9]*'
       - name: Cache the Maven packages to speed up build
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Updates the workflow to produce:
- for releases: `[version]` -> `11.2.4`
- for PRs: `[lastVersion][pr]-[newCommits]-[sha1]-SNAPSHOT` -> `11.2.3-PR12-4-deadbeef-SNAPSHOT`
- for branches: `[lastVersion][branch]-[newCommits]-[sha1]-SNAPSHOT` -> `11.2.3-fixBugs-2-deadbeef-SNAPSHOT`