### PR TITLE
Publisher error handling

### DIFF
--- a/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
+++ b/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import static io.opencmw.OpenCmwConstants.*;
 import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
+import static io.opencmw.OpenCmwProtocol.EMPTY_ZFRAME;
 import static io.opencmw.utils.AnsiDefs.ANSI_RED;
 import static io.opencmw.utils.AnsiDefs.ANSI_RESET;
 
@@ -31,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMsg;
 
@@ -95,7 +95,6 @@ import io.opencmw.utils.SystemProperties;
 @SuppressWarnings({ "PMD.GodClass", "PMD.ExcessiveImports", "PMD.TooManyFields" })
 public class DataSourcePublisher implements Runnable, Closeable {
     public static final int MIN_FRAMES_INTERNAL_MSG = 3;
-    protected static final ZFrame EMPTY_ZFRAME = new ZFrame(EMPTY_FRAME);
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourcePublisher.class);
     private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
 

--- a/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
+++ b/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
@@ -403,7 +403,7 @@ public class DataSourcePublisher implements Runnable, Closeable {
             publishEvent.payload.set(replyDomainObject);
         }
         if (exception != null && !exception.isBlank()) {
-            publishEvent.throwables.add(new Exception(exception));
+            publishEvent.throwables.add(new ProtocolException(exception));
         }
         final EvtTypeFilter evtTypeFilter = publishEvent.getFilter(EvtTypeFilter.class);
         // update other filter in destination ring-buffer

--- a/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
@@ -5,14 +5,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.zeromq.ZMonitor.Event;
 
 import static io.opencmw.OpenCmwConstants.*;
+import static io.opencmw.OpenCmwProtocol.*;
 import static io.opencmw.OpenCmwProtocol.Command.GET_REQUEST;
 import static io.opencmw.OpenCmwProtocol.Command.SET_REQUEST;
 import static io.opencmw.OpenCmwProtocol.Command.SUBSCRIBE;
 import static io.opencmw.OpenCmwProtocol.Command.UNSUBSCRIBE;
-import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
-import static io.opencmw.OpenCmwProtocol.EMPTY_URI;
-import static io.opencmw.OpenCmwProtocol.MdpMessage;
 import static io.opencmw.OpenCmwProtocol.MdpSubProtocol.PROT_CLIENT;
+import static io.opencmw.utils.AnsiDefs.ANSI_RED;
+import static io.opencmw.utils.AnsiDefs.ANSI_RESET;
 
 import java.io.IOException;
 import java.net.URI;
@@ -393,18 +393,18 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
     }
 
     public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception) {
-        return createInternalMsg(reqId, endpoint, body, exception, "OpenCmwDataSource");
+        return createInternalMsg(reqId, endpoint, body, exception, OpenCmwDataSource.class);
     }
 
-    public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception, final String dataSourceName) {
+    public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception, final Class<? extends DataSource> dataSource) {
         final ZMsg result = new ZMsg();
         result.add(reqId);
         result.add(endpoint.toString());
-        result.add(body == null ? new ZFrame(new byte[0]) : body);
+        result.add(body == null ? EMPTY_ZFRAME : body);
         if (exception == null || exception.isBlank()) {
-            result.add(new ZFrame(new byte[0]));
+            result.add(EMPTY_ZFRAME);
         } else {
-            result.add(new ZFrame(dataSourceName + " received exception for device " + endpoint + ":\n" + exception));
+            result.add(new ZFrame(ANSI_RED + dataSource.getSimpleName() + " received exception for device " + endpoint + ":\n" + exception + ANSI_RESET));
         }
         return result;
     }

--- a/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
@@ -366,7 +366,7 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
         case FINAL:
         case W_NOTIFY:
             if (msg.clientRequestID != null && msg.clientRequestID.length > 0) { // for get/set the request id is provided by the server
-                return createInternalMsg(msg.clientRequestID, msg.topic, new ZFrame(msg.data), msg.errors);
+                return createInternalMsg(msg.clientRequestID, msg.topic, new ZFrame(msg.data), msg.errors, OpenCmwDataSource.class);
             }
             // for subscriptions the request id is missing and has to be recovered from the endpoint url
             final Optional<String> reqId = subscriptions.entrySet().stream() //
@@ -374,7 +374,7 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
                                                    .map(Map.Entry::getKey)
                                                    .findFirst();
             if (reqId.isPresent()) {
-                return createInternalMsg(reqId.get().getBytes(), msg.topic, new ZFrame(msg.data), msg.errors);
+                return createInternalMsg(reqId.get().getBytes(), msg.topic, new ZFrame(msg.data), msg.errors, OpenCmwDataSource.class);
             }
             LOGGER.atWarn().addArgument(msg.topic).log("Could not find subscription for notified request with endpoint: {}");
             return new ZMsg(); // ignore unknown notification
@@ -390,10 +390,6 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
             LOGGER.atDebug().addArgument(msg).log("Ignoring unexpected message: {}");
             return new ZMsg(); // ignore unknown request
         }
-    }
-
-    public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception) {
-        return createInternalMsg(reqId, endpoint, body, exception, OpenCmwDataSource.class);
     }
 
     public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception, final Class<? extends DataSource> dataSource) {

--- a/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
@@ -393,11 +393,19 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
     }
 
     public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception) {
+        return createInternalMsg(reqId, endpoint, body, exception, "OpenCmwDataSource");
+    }
+
+    public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception, final String dataSourceName) {
         final ZMsg result = new ZMsg();
         result.add(reqId);
         result.add(endpoint.toString());
         result.add(body == null ? new ZFrame(new byte[0]) : body);
-        result.add(exception == null ? new ZFrame(new byte[0]) : new ZFrame(exception));
+        if (exception == null || exception.isBlank()) {
+            result.add(new ZFrame(new byte[0]));
+        } else {
+            result.add(new ZFrame(dataSourceName + " received exception for device " + endpoint + ":\n" + exception));
+        }
         return result;
     }
 }

--- a/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
+++ b/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
@@ -85,8 +85,8 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
     protected final URI endpoint;
     private final AtomicInteger reconnectAttempt = new AtomicInteger(0);
     private final ZMonitor socketMonitor;
-    private final Queue<Request> queuedRequests = new LinkedBlockingQueue<>();
-    private final Map<Long, Request> pendingRequests = new HashMap<>();
+    protected final Queue<Request> queuedRequests = new LinkedBlockingQueue<>();
+    protected final Map<Long, Request> pendingRequests = new HashMap<>();
     private final ExecutorService executorService;
     protected long connectionId;
     protected long lastHeartbeatReceived = -1;
@@ -565,7 +565,7 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
         public final String selector;
         public final Map<String, Object> filters;
         public final URI endpoint;
-        private final long id = REQUEST_ID_GENERATOR.incrementAndGet();
+        public final long id = REQUEST_ID_GENERATOR.incrementAndGet();
         public SubscriptionState subscriptionState = SubscriptionState.UNSUBSCRIBED;
         public int backOff = 20;
         public long updateId = -1;

--- a/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
+++ b/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
@@ -395,7 +395,7 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
             }
         case EXCEPTION:
             final Request requestForException = pendingRequests.remove(reply.id);
-            return createInternalMsg(requestForException.requestId.getBytes(UTF_8), requestForException.endpoint, null, "EXCEPTION: " + reply.exceptionMessage.message);
+            return createInternalMsg(requestForException.requestId.getBytes(UTF_8), requestForException.endpoint, null, "request exception: " + reply.exceptionMessage.message);
         case SUBSCRIBE:
             final long id = reply.id;
             final Subscription sub = subscriptions.get(id);
@@ -431,14 +431,14 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
                 LOGGER.atInfo().addArgument(reply.toString()).log("received unsolicited subscription notification error: {}");
                 return new ZMsg();
             }
-            return createInternalMsg(subscriptionForNotifyExc.idString.getBytes(UTF_8), subscriptionForNotifyExc.endpoint, null, "NOTIFICATION_EXCEPTION: " + reply.exceptionMessage.message);
+            return createInternalMsg(subscriptionForNotifyExc.idString.getBytes(UTF_8), subscriptionForNotifyExc.endpoint, null, "notification exception: " + reply.exceptionMessage.message);
         case SUBSCRIBE_EXCEPTION:
             final Subscription subForSubExc = subscriptions.get(reply.id);
             subForSubExc.subscriptionState = SubscriptionState.UNSUBSCRIBED;
             subForSubExc.timeoutValue = currentTime + subForSubExc.backOff;
             subForSubExc.backOff *= 2;
             LOGGER.atDebug().addArgument(subForSubExc.device).addArgument(subForSubExc.property).log("exception during subscription, retrying: {}/{}");
-            return createInternalMsg(subForSubExc.idString.getBytes(UTF_8), subForSubExc.endpoint, null, "SUBSCRIBE_EXCEPTION: " + reply.exceptionMessage.message);
+            return createInternalMsg(subForSubExc.idString.getBytes(UTF_8), subForSubExc.endpoint, null, "subscribe exception: " + reply.exceptionMessage.message);
         // unsupported or non-actionable replies
         case GET:
         case SET:
@@ -451,7 +451,7 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
     }
 
     public static ZMsg createInternalMsg(final byte[] reqId, final URI endpoint, final ZFrame body, final String exception) {
-        return OpenCmwDataSource.createInternalMsg(reqId, endpoint, body, exception, "CmwLightDataSource");
+        return OpenCmwDataSource.createInternalMsg(reqId, endpoint, body, exception, CmwLightDataSource.class);
     }
 
     private CmwLightMessage receiveData() {
@@ -590,9 +590,9 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
         public final byte[] data;
         public final long id;
         public final CmwLightProtocol.RequestType requestType;
-        private final String requestId;
-        private final URI endpoint;
-        private final byte[] rbacToken;
+        public final String requestId;
+        public final URI endpoint;
+        public final byte[] rbacToken;
 
         public Request(final CmwLightProtocol.RequestType requestType,
                 final String requestId,

--- a/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
+++ b/client/src/main/java/io/opencmw/client/cmwlight/CmwLightDataSource.java
@@ -337,7 +337,12 @@ public class CmwLightDataSource extends DataSource { // NOPMD - class should pro
 
     @Override
     public void unsubscribe(final String reqId) {
-        subscriptionsByReqId.get(reqId).subscriptionState = SubscriptionState.CANCELED;
+        final Subscription sub = subscriptionsByReqId.get(reqId);
+        if (sub.subscriptionState == SubscriptionState.UNSUBSCRIBED) {
+            subscriptions.remove(sub.id);
+            return;
+        }
+        sub.subscriptionState = SubscriptionState.CANCELED;
     }
 
     @Override

--- a/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
+++ b/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
@@ -3,6 +3,8 @@ package io.opencmw.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
+
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -28,6 +30,9 @@ import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.Utils;
+import org.zeromq.ZFrame;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMsg;
 
 import io.opencmw.EventStore;
 import io.opencmw.Filter;
@@ -316,7 +321,19 @@ class OpenCmwDataSourceTest {
 
     @Test
     void testMiscellaneous() {
+        // test TestObject constructor
         assertDoesNotThrow((ThrowingSupplier<TestObject>) TestObject::new);
+        // test createInternalMsg
+        final ZMsg msg1 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), new ZFrame(new byte[] { 42, 23 }), null));
+        assertArrayEquals(new byte[] { 1, 2, 3 }, msg1.pop().getData());
+        assertEquals("test", msg1.pop().getString(ZMQ.CHARSET));
+        assertArrayEquals(new byte[] { 42, 23 }, msg1.pop().getData());
+        assertEquals("", msg1.pop().getString(ZMQ.CHARSET));
+        final ZMsg msg2 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), null, "testexception"));
+        assertArrayEquals(new byte[] { 1, 2, 3 }, msg2.pop().getData());
+        assertEquals("test", msg2.pop().getString(ZMQ.CHARSET));
+        assertArrayEquals(EMPTY_FRAME, msg2.pop().getData());
+        assertThat(msg2.pop().getString(ZMQ.CHARSET), Matchers.containsString("testexception"));
     }
 
     public static class TestObject {

--- a/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
+++ b/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
@@ -324,12 +324,12 @@ class OpenCmwDataSourceTest {
         // test TestObject constructor
         assertDoesNotThrow((ThrowingSupplier<TestObject>) TestObject::new);
         // test createInternalMsg
-        final ZMsg msg1 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), new ZFrame(new byte[] { 42, 23 }), null));
+        final ZMsg msg1 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), new ZFrame(new byte[] { 42, 23 }), null, OpenCmwDataSource.class));
         assertArrayEquals(new byte[] { 1, 2, 3 }, msg1.pop().getData());
         assertEquals("test", msg1.pop().getString(ZMQ.CHARSET));
         assertArrayEquals(new byte[] { 42, 23 }, msg1.pop().getData());
         assertEquals("", msg1.pop().getString(ZMQ.CHARSET));
-        final ZMsg msg2 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), null, "testexception"));
+        final ZMsg msg2 = assertDoesNotThrow(() -> OpenCmwDataSource.createInternalMsg(new byte[] { 1, 2, 3 }, URI.create("test"), null, "testexception", OpenCmwDataSource.class));
         assertArrayEquals(new byte[] { 1, 2, 3 }, msg2.pop().getData());
         assertEquals("test", msg2.pop().getString(ZMQ.CHARSET));
         assertArrayEquals(EMPTY_FRAME, msg2.pop().getData());

--- a/client/src/test/java/io/opencmw/client/cmwlight/CmwLightDataSourceTest.java
+++ b/client/src/test/java/io/opencmw/client/cmwlight/CmwLightDataSourceTest.java
@@ -9,7 +9,6 @@ import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -92,12 +91,120 @@ class CmwLightDataSourceTest {
                     final ZMsg reply = client.getMessage(); // Make client receive ack and update connection status
                     client.housekeeping(); // allow the subscription to be sent out
 
-                    return reply.size() == 4 && reply.pollFirst().getString(Charset.defaultCharset()).equals("testId")
-                            && Objects.requireNonNull(reply.pollFirst()).getString(Charset.defaultCharset()).equals(new CmwLightDataSource.ParsedEndpoint(endpoint, cycleName).toURI().toString())
-                            && Objects.requireNonNull(reply.pollFirst()).getString(Charset.defaultCharset()).equals("data")
+                    return reply != null && reply.size() == 4
+                            && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(reqId)
+                            && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(new CmwLightDataSource.ParsedEndpoint(endpoint, cycleName).toURI().toString())
+                            && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals("data")
                             && Objects.requireNonNull(reply.pollFirst()).getData().length == 0;
                 });
             }
+
+            // send notification exception
+            CmwLightProtocol.sendMsg(socket, CmwLightMessage.notificationExceptionReply(subMsg.sessionId, sourceId, "", "", "testException", 133713371337L, 133713371337L, (byte) 0));
+            // assert that the subscription notify exception was received
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(() -> {
+                final ZMsg reply = client.getMessage(); // Make client receive ack and update connection status
+                client.housekeeping(); // allow the subscription to be sent out
+
+                return reply != null && reply.size() == 4
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(reqId)
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(endpoint.toString())
+                        && Objects.requireNonNull(reply.pollFirst()).getData().length == 0
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).contains("testException");
+            });
+
+            // unsubscribe
+            client.unsubscribe(reqId);
+            // assert that the unsubscribe request was sent
+            final CmwLightMessage unsubscribeMsg = getNextNonHeartbeatMsg(socket, client);
+            assertEquals(CmwLightProtocol.MessageType.CLIENT_REQ, unsubscribeMsg.messageType);
+            assertEquals(CmwLightProtocol.RequestType.UNSUBSCRIBE, unsubscribeMsg.requestType);
+            // confirm the unsubscribe
+            final CmwLightMessage unsubscribeReply = CmwLightMessage.unsubscribeRequest(subMsg.sessionId, sourceId, subMsg.deviceName, subMsg.propertyName, Map.of(CmwLightProtocol.FieldName.SOURCE_ID_TAG.value(), sourceId), CmwLightProtocol.UpdateType.NORMAL);
+            unsubscribeReply.messageType = CmwLightProtocol.MessageType.SERVER_REP;
+            CmwLightProtocol.sendMsg(socket, unsubscribeReply);
+            // assert that the subscription was removed
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(() -> {
+                client.getMessage(); // Make client receive ack and update connection status
+                client.housekeeping(); // allow the subscription to be sent out
+                return !client.replyIdMap.containsKey(sourceId);
+            });
+
+            // subscription with error
+            final String subErrorReqId = "subErrorReqId";
+            client.subscribe(subErrorReqId, endpoint, null);
+
+            final CmwLightMessage subErrorMsg = getNextNonHeartbeatMsg(socket, client);
+            assertEquals(CmwLightProtocol.MessageType.CLIENT_REQ, subErrorMsg.messageType);
+            assertEquals(CmwLightProtocol.RequestType.SUBSCRIBE, subErrorMsg.requestType);
+            assertEquals(Map.of("nFilter", 1), subErrorMsg.requestContext.filters);
+
+            // send subscription error
+            CmwLightProtocol.sendMsg(socket, CmwLightMessage.subscribeExceptionReply(subErrorMsg.sessionId, subErrorMsg.id, subErrorMsg.deviceName, subErrorMsg.propertyName, "testException", 1337L, 1337L, (byte) 0));
+
+            // receive subscription error
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(() -> {
+                final ZMsg reply = client.getMessage(); // Make client receive ack and update connection status
+                client.housekeeping(); // perform housekeeping duties
+
+                return reply != null && reply.size() == 4
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(subErrorReqId)
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(endpoint.toString())
+                        && Objects.requireNonNull(reply.pollFirst()).getData().length == 0
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).contains("testException");
+            });
+
+            // unsubscibe failing subscription
+            client.unsubscribe(subErrorReqId);
+            assertEquals(0, client.subscriptions.size()); // because the subscription was not successfull, it will be deleted without network action
+
+            // get request
+            final String getReqId = "getReqId";
+            client.get(getReqId, endpoint, null, null);
+            // assert that get request was sent
+            final CmwLightMessage getMsg = getNextNonHeartbeatMsg(socket, client);
+            assertEquals(CmwLightProtocol.MessageType.CLIENT_REQ, getMsg.messageType);
+            assertEquals(CmwLightProtocol.RequestType.GET, getMsg.requestType);
+            assertEquals(Map.of("nFilter", 1), getMsg.requestContext.filters);
+            // send get request reply and assert that it was received
+            final String cycleName = "FAIR.SELECTOR.C=1337";
+            final long getSourceId = client.pendingRequests.keySet().stream().findFirst().orElseThrow();
+            CmwLightProtocol.sendMsg(socket, CmwLightMessage.getReply(subMsg.sessionId, getSourceId, "", "", new ZFrame("data"),
+                                                     new CmwLightMessage.DataContext(cycleName, 123456789, 123456788, null)));
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(() -> {
+                final ZMsg reply = client.getMessage(); // Make client receive ack and update connection status
+                client.housekeeping(); // perform housekeeping duties
+
+                return reply != null && reply.size() == 4
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(getReqId)
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(new CmwLightDataSource.ParsedEndpoint(endpoint, cycleName).toURI().toString())
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals("data")
+                        && Objects.requireNonNull(reply.pollFirst()).getData().length == 0;
+            });
+
+            // get request with error
+            final String getErrorReqId = "getErrorReqId";
+            client.get(getErrorReqId, endpoint, null, null);
+            // assert that get request was sent
+            final CmwLightMessage getErrorMsg = getNextNonHeartbeatMsg(socket, client);
+            assertEquals(CmwLightProtocol.MessageType.CLIENT_REQ, getErrorMsg.messageType);
+            assertEquals(CmwLightProtocol.RequestType.GET, getErrorMsg.requestType);
+            assertEquals(Map.of("nFilter", 1), getErrorMsg.requestContext.filters);
+            // send get request reply and assert that it was received
+            assertEquals(1, client.pendingRequests.size());
+            final long getErrorSourceId = client.pendingRequests.keySet().stream().findFirst().orElseThrow();
+            CmwLightProtocol.sendMsg(socket, CmwLightMessage.exceptionReply(subMsg.sessionId, getErrorSourceId, "", "", "testException", 133713371337L, 133713371337L, (byte) 0));
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(() -> {
+                final ZMsg reply = client.getMessage(); // Make client receive ack and update connection status
+                client.housekeeping(); // perform housekeeping duties
+
+                return reply != null && reply.size() == 4
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(getErrorReqId)
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).equals(endpoint.toString())
+                        && Objects.requireNonNull(reply.pollFirst()).getData().length == 0
+                        && Objects.requireNonNull(reply.pollFirst()).getString(ZMQ.CHARSET).contains("testException");
+            });
+
             client.close();
         }
     }
@@ -135,6 +242,12 @@ class CmwLightDataSourceTest {
         assertFalse(factory.matches(URI.create("tcp://server/device/property?query=test")));
         assertTrue(factory.matches(URI.create("rda3:/testdevice/property")));
         assertFalse(factory.matches(URI.create("https://testserver")));
+    }
+
+    @Test
+    void testSubscription() {
+        final CmwLightDataSource.Subscription sub = new CmwLightDataSource.Subscription(URI.create("testuri"), "testdevice", "testproperty", "testselector", Map.of("testFilter", 42));
+        assertEquals("Subscription{property='testproperty', device='testdevice', selector='testselector', filters={testFilter=42}, subscriptionState=UNSUBSCRIBED, backOff=20, id=" + sub.id + ", updateId=-1, timeoutValue=-1}", sub.toString());
     }
 
     @Test

--- a/client/src/test/java/io/opencmw/client/cmwlight/CmwLightEventStoreSample.java
+++ b/client/src/test/java/io/opencmw/client/cmwlight/CmwLightEventStoreSample.java
@@ -1,6 +1,6 @@
 package io.opencmw.client.cmwlight;
 
-import static io.opencmw.client.cmwlight.CmwLightExample.*;
+import static io.opencmw.client.cmwlight.CmwLightExample.ChannelConfig;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -8,18 +8,21 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
 
+import io.opencmw.EventStore;
 import io.opencmw.client.DataSource;
 import io.opencmw.client.DataSourcePublisher;
 import io.opencmw.client.cmwlight.CmwLightExample.AcquisitionDAQ;
 import io.opencmw.domain.NoData;
+import io.opencmw.filter.EvtTypeFilter;
+import io.opencmw.filter.TimingCtx;
 
 /**
- * Create a DataSourcePublisher and demonstrate subscription with with the listener interface and get with the future
- * interface. Also demonstrates error handling.
- * For the same example using the event store api, see {@link CmwLightEventStoreSample}
+ * Create a DataSourcePublisher and demonstrate subscription with with the event store interface. Also demonstrates error handling.
+ * For the same example using the listener/future api, see {@link CmwLightViaPublisherExample}
  */
-public class CmwLightViaPublisherExample {
+public class CmwLightEventStoreSample {
     private final static String DEVICE = "GSCD002";
     private final static String PROPERTY = "AcquisitionDAQ";
     private static final String CONFIG_PROPERTY = "ChannelConfigDAQ";
@@ -30,6 +33,18 @@ public class CmwLightViaPublisherExample {
             System.out.println("no directory server supplied");
             return;
         }
+        // setup event store and listeners
+        final EventStore eventStore = EventStore.getFactory().setFilterConfig(TimingCtx.class, EvtTypeFilter.class).build();
+        AtomicInteger eventStoreCounter = new AtomicInteger(0);
+        eventStore.register((ev, id, isLast) -> {
+            final int n = eventStoreCounter.getAndIncrement();
+            if (ev.throwables.size() == 0) {
+                System.out.println(n + ": store event with payload " + ev.payload.get());
+            } else {
+                System.out.println(n + ": store event with exceptions\n" + ev.throwables.stream().map(Throwable::toString).collect(Collectors.joining(", ", "[", "]")));
+            }
+        });
+        eventStore.start();
 
         final URI getURIWithError = new URI("rda3", null, '/' + DEVICE + '/' + "NonexistentProperty", null, null);
         final URI getURI = new URI("rda3", null, '/' + DEVICE + '/' + CONFIG_PROPERTY, null, null);
@@ -38,42 +53,24 @@ public class CmwLightViaPublisherExample {
         String filtersString = "acquisitionModeFilter=int:0&channelNameFilter=GS11MU2:Current_1@10Hz";
         final URI subURI = new URI("rda3", null, '/' + DEVICE + '/' + PROPERTY, "ctx=" + SELECTOR + "&" + filtersString, null);
 
-        try (final DataSourcePublisher dataSourcePublisher = new DataSourcePublisher(null, null, "test-client");
+        try (final DataSourcePublisher dataSourcePublisher = new DataSourcePublisher(null, eventStore, null, null, "test-client");
                 final DataSourcePublisher.Client client = dataSourcePublisher.getClient()) {
+            dataSourcePublisher.start();
+
             // set DNS reference
             DataSource.getFactory(URI.create("rda3:/")).registerDnsResolver(new DirectoryLightClient(args[0]));
 
             // subscription with illegal properties to test exception handling
             System.out.println("Subscription with error");
             final AtomicInteger errorNotificationCounter = new AtomicInteger();
-            final String sub = client.subscribe(subURIWithError, AcquisitionDAQ.class, null, NoData.class, new DataSourcePublisher.NotificationListener<>() {
-                @Override
-                public void dataUpdate(final AcquisitionDAQ updatedObject, final NoData contextObject) {
-                    System.out.println(errorNotificationCounter.getAndIncrement() + ": notified property with " + updatedObject);
-                }
-
-                @Override
-                public void updateException(final Throwable exception) {
-                    System.out.println(errorNotificationCounter.getAndIncrement() + ": notification exception: " + exception);
-                }
-            });
+            final String sub = client.subscribe(subURIWithError, AcquisitionDAQ.class, null, NoData.class, null);
             LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(2));
             client.unsubscribe(sub); // unsubscribe invalid subscription
 
             // subscription
             System.out.println("Correct subscription");
             final AtomicInteger notificationCounter = new AtomicInteger();
-            final String sub2 = client.subscribe(subURI, AcquisitionDAQ.class, null, NoData.class, new DataSourcePublisher.NotificationListener<>() {
-                @Override
-                public void dataUpdate(final AcquisitionDAQ updatedObject, final NoData contextObject) {
-                    System.out.println(notificationCounter.getAndIncrement() + ": notified property (unexpected, should be exception) with " + updatedObject);
-                }
-
-                @Override
-                public void updateException(final Throwable exception) {
-                    System.out.println(notificationCounter.getAndIncrement() + ": notification exception (expected): " + exception);
-                }
-            });
+            final String sub2 = client.subscribe(subURI, AcquisitionDAQ.class, null, NoData.class, null);
             System.out.println("start monitoring");
             LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(5));
             System.out.println("counted notification: " + notificationCounter.get());
@@ -81,27 +78,17 @@ public class CmwLightViaPublisherExample {
 
             // get request with error
             System.out.println("Get request with error");
-            final Future<ChannelConfig> futureError = client.get(getURIWithError, null, ChannelConfig.class);
-            try {
-                final ChannelConfig result = futureError.get(1, TimeUnit.SECONDS);
-                System.out.println("Result of get request: " + result);
-            } catch (Exception e) {
-                System.out.println("Error during get request: " + e);
-            }
+            client.get(getURIWithError, null, ChannelConfig.class);
             LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(1));
 
             // get request with error
             System.out.println("Get request");
             final Future<ChannelConfig> futureResult = client.get(getURI, null, ChannelConfig.class);
-            try {
-                final ChannelConfig result = futureResult.get(1, TimeUnit.SECONDS);
-                System.out.println("Result of get request (unexpected, should have thrown exception): " + result);
-            } catch (Exception e) {
-                System.out.println("Error during get request (expected): " + e);
-            }
+            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(1));
 
             dataSourcePublisher.stop();
             dataSourcePublisher.getContext().destroy();
         }
+        eventStore.stop();
     }
 }

--- a/client/src/test/java/io/opencmw/client/cmwlight/CmwLightExample.java
+++ b/client/src/test/java/io/opencmw/client/cmwlight/CmwLightExample.java
@@ -147,4 +147,24 @@ public class CmwLightExample { // NOPMD is not a utility class but a sample
             return "SnoopAcquisition{TriggerEventName='" + TriggerEventName + '\'' + ", acquisitionStamp=" + acquisitionStamp + ", chainIndex=" + chainIndex + ", chainStartStamp=" + chainStartStamp + ", eventNumber=" + eventNumber + ", eventStamp=" + eventStamp + ", processIndex=" + processIndex + ", processStartStamp=" + processStartStamp + ", sequenceIndex=" + sequenceIndex + ", sequenceStartStamp=" + sequenceStartStamp + ", timingGroupID=" + timingGroupID + '}';
         }
     }
+
+    public static class ChannelConfig {
+        public String[] channelNames;
+        public String[] channelUnits;
+        public float[] channelDataRates;
+        public String[] triggerEvents;
+        public String[] status_labels;
+        public int[] status_severity;
+
+        @Override
+        public String toString() {
+            return "ChannelConfig{" //
+                    + "channelNames=" + Arrays.toString(channelNames) //
+                    + ", channelUnits=" + Arrays.toString(channelUnits) //
+                    + ", channelDataRates=" + Arrays.toString(channelDataRates) //
+                    + ", triggerEvents=" + Arrays.toString(triggerEvents) //
+                    + ", status_labels=" + Arrays.toString(status_labels) //
+                    + ", status_severity=" + Arrays.toString(status_severity) + '}';
+        }
+    }
 }

--- a/client/src/test/java/io/opencmw/client/cmwlight/CmwLightViaPublisherExample.java
+++ b/client/src/test/java/io/opencmw/client/cmwlight/CmwLightViaPublisherExample.java
@@ -1,22 +1,28 @@
 package io.opencmw.client.cmwlight;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static io.opencmw.client.cmwlight.CmwLightExample.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
 
+import io.opencmw.EventStore;
 import io.opencmw.client.DataSource;
 import io.opencmw.client.DataSourcePublisher;
 import io.opencmw.client.cmwlight.CmwLightExample.AcquisitionDAQ;
 import io.opencmw.domain.NoData;
+import io.opencmw.filter.EvtTypeFilter;
+import io.opencmw.filter.TimingCtx;
 
 public class CmwLightViaPublisherExample {
     private final static String DEVICE = "GSCD002";
     // private final static String PROPERTY = "SnoopTriggerEvents";
     private final static String PROPERTY = "AcquisitionDAQ";
+    private static final String CONFIG_PROPERTY = "ChannelConfigDAQ";
     private final static String SELECTOR = "FAIR.SELECTOR.ALL";
 
     public static void main(String[] args) throws URISyntaxException {
@@ -24,31 +30,93 @@ public class CmwLightViaPublisherExample {
             System.out.println("no directory server supplied");
             return;
         }
+        // setup event store and listeners
+        final EventStore eventStore = EventStore.getFactory().setFilterConfig(TimingCtx.class, EvtTypeFilter.class).build();
+        AtomicInteger eventStoreCounter = new AtomicInteger(0);
+        eventStore.register((ev, id, isLast) -> {
+            final int n = eventStoreCounter.getAndIncrement();
+            if (ev.throwables.size() == 0) {
+                System.out.println(n + ": store event with payload " + ev.payload.get());
+            } else {
+                System.out.println(n + ": store event with exceptions\n" + ev.throwables.stream().map(Throwable::toString).collect(Collectors.joining(", ", "[", "]")));
+            }
+        });
+        eventStore.start();
 
+        final URI getURIWithError = new URI("rda3", null, '/' + DEVICE + '/' + "NonexistentProperty", null, null);
+        final URI getURI = new URI("rda3", null, '/' + DEVICE + '/' + CONFIG_PROPERTY, null, null);
+        String filtersStringWithError = "acquisitionModeFilter=int:0&channelNameFilter=nonexistentChannel";
+        final URI subURIWithError = new URI("rda3", null, '/' + DEVICE + '/' + PROPERTY, "ctx=" + SELECTOR + "&" + filtersStringWithError, null);
         String filtersString = "acquisitionModeFilter=int:0&channelNameFilter=GS11MU2:Current_1@10Hz";
         final URI subURI = new URI("rda3", null, '/' + DEVICE + '/' + PROPERTY, "ctx=" + SELECTOR + "&" + filtersString, null);
 
-        try (DataSourcePublisher dataSource = new DataSourcePublisher(null, null, "test-client");
-                DataSourcePublisher.Client client = dataSource.getClient()) {
+        try (final DataSourcePublisher dataSourcePublisher = new DataSourcePublisher(null, eventStore, null, null, "test-client");
+                final DataSourcePublisher.Client client = dataSourcePublisher.getClient()) {
+            dataSourcePublisher.start();
+
             // set DNS reference
             DataSource.getFactory(URI.create("rda3:/")).registerDnsResolver(new DirectoryLightClient(args[0]));
 
-            AtomicInteger notificationCounter = new AtomicInteger();
-            client.subscribe(subURI, AcquisitionDAQ.class, null, NoData.class, new DataSourcePublisher.NotificationListener<>() {
+            // subscription with illegal properties to test exception handling
+            System.out.println("Subscription with error");
+            final AtomicInteger errorNotificationCounter = new AtomicInteger();
+            final String sub = client.subscribe(subURIWithError, AcquisitionDAQ.class, null, NoData.class, new DataSourcePublisher.NotificationListener<>() {
                 @Override
                 public void dataUpdate(final AcquisitionDAQ updatedObject, final NoData contextObject) {
-                    System.out.println(notificationCounter.get() + ": notified property with " + updatedObject);
-                    notificationCounter.getAndIncrement();
+                    System.out.println(errorNotificationCounter.getAndIncrement() + ": notified property with " + updatedObject);
                 }
 
                 @Override
                 public void updateException(final Throwable exception) {
-                    fail("subscription exception occurred ", exception);
+                    System.out.println(errorNotificationCounter.getAndIncrement() + ": notification exception: " + exception);
+                }
+            });
+            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(2));
+            client.unsubscribe(sub); // unsubscribe invalid subscription
+
+            // subscription
+            System.out.println("Correct subscription");
+            final AtomicInteger notificationCounter = new AtomicInteger();
+            final String sub2 = client.subscribe(subURI, AcquisitionDAQ.class, null, NoData.class, new DataSourcePublisher.NotificationListener<>() {
+                @Override
+                public void dataUpdate(final AcquisitionDAQ updatedObject, final NoData contextObject) {
+                    System.out.println(notificationCounter.getAndIncrement() + ": notified property with " + updatedObject);
+                }
+
+                @Override
+                public void updateException(final Throwable exception) {
+                    System.out.println(notificationCounter.getAndIncrement() + ": notification exception: " + exception);
                 }
             });
             System.out.println("start monitoring");
-            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(10));
+            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(5));
             System.out.println("counted notification: " + notificationCounter.get());
+            client.unsubscribe(sub2);
+
+            // get request with error
+            System.out.println("Get request with error");
+            final Future<ChannelConfig> futureError = client.get(getURIWithError, null, ChannelConfig.class);
+            try {
+                final ChannelConfig result = futureError.get(1, TimeUnit.SECONDS);
+                System.out.println("Result of get request: " + result);
+            } catch (Exception e) {
+                System.out.println("Error during get request: " + e);
+            }
+            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(1));
+
+            // get request with error
+            System.out.println("Get request");
+            final Future<ChannelConfig> futureResult = client.get(getURI, null, ChannelConfig.class);
+            try {
+                final ChannelConfig result = futureResult.get(1, TimeUnit.SECONDS);
+                System.out.println("Result of get request: " + result);
+            } catch (Exception e) {
+                System.out.println("Error during get request: " + e);
+            }
+
+            dataSourcePublisher.stop();
+            dataSourcePublisher.getContext().destroy();
         }
+        eventStore.stop();
     }
 }

--- a/core/src/main/java/io/opencmw/OpenCmwProtocol.java
+++ b/core/src/main/java/io/opencmw/OpenCmwProtocol.java
@@ -44,6 +44,12 @@ import io.opencmw.utils.AnsiDefs;
 public final class OpenCmwProtocol { // NOPMD - nomen est omen
     public static final String COMMAND_MUST_NOT_BE_NULL = "command must not be null";
     public static final byte[] EMPTY_FRAME = {};
+    public static final ZFrame EMPTY_ZFRAME = new ZFrame(EMPTY_FRAME) {
+        @Override
+        public void destroy() {
+            // do not remove the contents of this special ZFrame after sending
+        }
+    };
     public static final byte[] BROKER_SHUTDOWN = "broker shutdown".getBytes(UTF_8);
     public static final URI EMPTY_URI = URI.create("");
     private static final byte[] PROTOCOL_NAME_CLIENT = "MDPC03".getBytes(UTF_8);


### PR DESCRIPTION
Improve the error handling of the DataSourcePublisher including context to exceptions in server replies. Additionally the CmwLightViaPublisherExample was extended to also demonstrate usage of the EventStore, errors and get requests.