### PR TITLE
Broker and Worker Life-Cycle improvements

### DIFF
--- a/client/src/main/java/io/opencmw/client/DataSource.java
+++ b/client/src/main/java/io/opencmw/client/DataSource.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jetbrains.annotations.NotNull;
 import org.zeromq.ZContext;
@@ -23,6 +24,7 @@ import io.opencmw.utils.NoDuplicatesList;
  */
 public abstract class DataSource implements AutoCloseable {
     private static final List<Factory> IMPLEMENTATIONS = Collections.synchronizedList(new NoDuplicatesList<>());
+    public final AtomicBoolean closed = new AtomicBoolean(false);
 
     private DataSource() {
         // prevent implementers from implementing default constructor
@@ -36,6 +38,13 @@ public abstract class DataSource implements AutoCloseable {
         if (!getFactory().matches(endpoint)) {
             throw new UnsupportedOperationException(this.getClass().getName() + " DataSource Implementation does not support endpoint: " + endpoint);
         }
+    }
+
+    /**
+     * @return {@code true} if this DataSource and its resources have been closed
+     */
+    public boolean isClosed() {
+        return closed.get();
     }
 
     /**

--- a/client/src/main/java/io/opencmw/client/DataSource.java
+++ b/client/src/main/java/io/opencmw/client/DataSource.java
@@ -157,7 +157,7 @@ public abstract class DataSource implements AutoCloseable {
             if (list.isEmpty()) {
                 throw new IllegalArgumentException("resolver schemes not compatible with this DataSource: " + resolver);
             }
-            getRegisteredDnsResolver().add(resolver);
+            getRegisteredDnsResolver().add(0, resolver); // add new resolvers in the beginning of the list to have higher priority
         }
     }
 

--- a/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
@@ -137,7 +137,7 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
             throw new UnsupportedOperationException("RADIO-DISH pattern is not yet implemented"); // well yes, but not released by the JeroMQ folks
             //this.socket = context.createSocket(SocketType.DISH)
         default:
-            throw new UnsupportedOperationException("Unsupported protocol type " + endpoint.getScheme());
+            throw new UnsupportedOperationException("Unsupported protocol type " + endpoint.getScheme()); // can only be reached if someone fiddles with the factory method
         }
         setDefaultSocketParameters(socket);
 

--- a/client/src/main/java/io/opencmw/client/OpenCmwDnsResolver.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDnsResolver.java
@@ -10,8 +10,11 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -48,7 +51,6 @@ public class OpenCmwDnsResolver implements DnsResolver, AutoCloseable {
         this.timeOut = timeOut;
         dataSource = new DataSourcePublisher(context, null, null, null, OpenCmwDnsResolver.class.getName());
         dataSource.start();
-        LockSupport.parkNanos(Duration.ofMillis(1000).toNanos()); // wait until DNS client has been initialised
     }
 
     @Override
@@ -77,7 +79,7 @@ public class OpenCmwDnsResolver implements DnsResolver, AutoCloseable {
 
     @Override
     public void close() {
-        dataSource.close();
+        dataSource.stop();
         if (ownsCtx) {
             context.close();
         }

--- a/client/src/test/java/io/opencmw/client/DataSourcePublisherTest.java
+++ b/client/src/test/java/io/opencmw/client/DataSourcePublisherTest.java
@@ -367,7 +367,8 @@ class DataSourcePublisherTest {
         final DataSourcePublisher dataSourcePublisher = new DataSourcePublisher(null, eventStore, null, null, "testGetPublisher");
 
         eventStore.start();
-        new Thread(dataSourcePublisher).start();
+        assertDoesNotThrow(dataSourcePublisher::start);
+        assertDoesNotThrow(dataSourcePublisher::start); // second invocation is being blocked
 
         final Future<TestObject> future;
         try (final DataSourcePublisher.Client client = dataSourcePublisher.getClient()) {

--- a/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
+++ b/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
@@ -221,6 +221,9 @@ class DnsDataSourceTests {
 
     @AfterAll
     static void finish() {
+        // delete previous resolvers
+        DataSource.getFactory(URI.create("mdp:/mmi.dns")).getRegisteredDnsResolver().clear();
+        openCmwResolver.close();
         brokerC.stopBroker();
         brokerB.stopBroker();
         dnsBroker.stopBroker();
@@ -244,7 +247,7 @@ class DnsDataSourceTests {
             public void run() {
                 try {
                     worker.notify(noData, domainData);
-                } catch (Exception e) {
+                } catch (Exception e) { // NOPMD
                     fail("exception in notify");
                 }
             }

--- a/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
+++ b/client/src/test/java/io/opencmw/client/OpenCmwDataSourceTest.java
@@ -346,7 +346,7 @@ class OpenCmwDataSourceTest {
         final ExecutorService executors = Executors.newCachedThreadPool();
         final String clientID = "test-client";
         try (ZContext ctx = new ZContext()) {
-            assertDoesNotThrow(() -> {
+            assertDoesNotThrow(() -> { // connect to non resolvable device -> source will retry to connect
                 try (DataSource source = new OpenCmwDataSource(ctx, URI.create("mdp:/device/property"), Duration.ofMillis(100), executors, clientID)) {
                     assertNotNull(source.toString());
                 }

--- a/core/src/main/java/io/opencmw/OpenCmwConstants.java
+++ b/core/src/main/java/io/opencmw/OpenCmwConstants.java
@@ -50,6 +50,8 @@ public final class OpenCmwConstants {
     public static final int HIGH_WATER_MARK_DEFAULT = 0; //
     public static final String CLIENT_TIMEOUT = "OpenCMW.clientTimeOut"; // [s]
     public static final long CLIENT_TIMEOUT_DEFAULT = 0L; // [s]
+    public static final String DNS_TIMEOUT = "OpenCMW.dnsTimeOut"; // [s]
+    public static final long DNS_TIMEOUT_DEFAULT = 10L; // [s]
     public static final String ADDRESS_GIVEN = "address given: ";
     public static final String RECONNECT_THRESHOLD1 = "OpenCMW.reconnectThreshold1"; // []
     public static final int DEFAULT_RECONNECT_THRESHOLD1 = 3; // []

--- a/core/src/main/java/io/opencmw/OpenCmwConstants.java
+++ b/core/src/main/java/io/opencmw/OpenCmwConstants.java
@@ -144,6 +144,7 @@ public final class OpenCmwConstants {
         socket.setHeartbeatTtl(heartBeatInterval * liveness);
         socket.setHeartbeatTimeout(heartBeatInterval * liveness);
         socket.setHeartbeatIvl(heartBeatInterval);
+        socket.setLinger(heartBeatInterval);
     }
 
     public static URI stripPathTrailingSlash(final @NotNull URI address) {


### PR DESCRIPTION
* added broker and worker init/destruction unit-tests
* improved resource shutdown/life-cycle management for the Majordomo-Broker and -Worker
* changed 'while' to 'do-while' spinning/polling loops (better in case of shut-down)
* additional logger statements/try-catch for shutdown diagnostics
* removed seemingly unnecessary sleep/wait statements