### PR TITLE
Improve handling of blocking builds by adding timeouts

### DIFF
--- a/client/src/test/java/io/opencmw/client/DataSourcePublisherTest.java
+++ b/client/src/test/java/io/opencmw/client/DataSourcePublisherTest.java
@@ -262,6 +262,7 @@ class DataSourcePublisherTest {
     }
 
     @BeforeAll
+    @Timeout(10)
     static void registerDataSource() {
         DataSource.register(TestDataSource.FACTORY);
     }

--- a/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
+++ b/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
@@ -199,6 +199,7 @@ class DnsDataSourceTests {
     }
 
     @BeforeAll
+    @Timeout(10)
     static void init() throws IOException {
         System.setProperty(OpenCmwConstants.HEARTBEAT, "100"); // to reduce waiting time for changes
         dnsBroker = getTestBroker("dnsBroker", "deviceA/property", null);
@@ -220,6 +221,7 @@ class DnsDataSourceTests {
     }
 
     @AfterAll
+    @Timeout(10)
     static void finish() {
         // delete previous resolvers
         DataSource.getFactory(URI.create("mdp:/mmi.dns")).getRegisteredDnsResolver().clear();

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
+coverage:
+  status:
+    default:
+      threshold: 0.15 # allow the overall coverage to decrease by 0.15 so that PRs only touching few code lines will not fail because of the noise
 ignore:
   - "*/src/test/**/*"

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,10 @@
                     <forkCount>1</forkCount>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
                     <runOrder>random</runOrder>
+                    <parallelTestsTimeoutInSeconds>30</parallelTestsTimeoutInSeconds>
+                    <parallelTestsTimeoutForcedInSeconds>45</parallelTestsTimeoutForcedInSeconds>
+                    <forkedProcessTimeoutInSeconds>360</forkedProcessTimeoutInSeconds>
+                    <forkedProcessExitTimeoutInSeconds>400</forkedProcessExitTimeoutInSeconds>
                 </configuration>
             </plugin>
             <plugin>

--- a/server-rest/src/test/java/io/opencmw/server/rest/MajordomoRestPluginTests.java
+++ b/server-rest/src/test/java/io/opencmw/server/rest/MajordomoRestPluginTests.java
@@ -67,6 +67,7 @@ class MajordomoRestPluginTests {
     private static OkHttpClient okHttp;
 
     @BeforeAll
+    @Timeout(10)
     static void init() throws IOException {
         okHttp = getUnsafeOkHttpClient(); // N.B. ignore SSL certificates
         primaryBroker = new MajordomoBroker(PRIMARY_BROKER, null, BasicRbacRole.values());
@@ -101,6 +102,7 @@ class MajordomoRestPluginTests {
     }
 
     @AfterAll
+    @Timeout(10)
     static void finish() {
         secondaryBroker.stopBroker();
         primaryBroker.stopBroker();

--- a/server/src/test/java/io/opencmw/server/BasicMdpWorkerTest.java
+++ b/server/src/test/java/io/opencmw/server/BasicMdpWorkerTest.java
@@ -35,6 +35,7 @@ import io.opencmw.utils.SystemProperties;
 @Timeout(60)
 class BasicMdpWorkerTest {
     @BeforeAll
+    @Timeout(10)
     void init() {
         System.getProperties().setProperty("OpenCMW.heartBeat", "50");
         assertEquals(50, SystemProperties.getValueIgnoreCase("OpenCMW.heartBeat", 2500), "reduced heart-beat interval");

--- a/server/src/test/java/io/opencmw/server/ClipboardWorkerTests.java
+++ b/server/src/test/java/io/opencmw/server/ClipboardWorkerTests.java
@@ -12,10 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +34,7 @@ class ClipboardWorkerTests {
     private URI extBrokerPublisherAddress;
 
     @BeforeAll
+    @Timeout(10)
     void init() throws IOException {
         broker = new MajordomoBroker("TestMdpBroker", null, BasicRbacRole.values());
         // broker.setDaemon(true); // use this if running in another app that
@@ -56,6 +54,7 @@ class ClipboardWorkerTests {
     }
 
     @AfterAll
+    @Timeout(10)
     void finish() {
         broker.stopBroker();
     }

--- a/server/src/test/java/io/opencmw/server/MajordomoWorkerTests.java
+++ b/server/src/test/java/io/opencmw/server/MajordomoWorkerTests.java
@@ -26,10 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
@@ -162,6 +159,7 @@ class MajordomoWorkerTests {
     }
 
     @BeforeAll
+    @Timeout(10)
     void startBroker() throws IOException {
         broker = new MajordomoBroker("TestBroker", null, BasicRbacRole.values());
         // broker.setDaemon(true); // use this if running in another app that controls threads
@@ -174,6 +172,7 @@ class MajordomoWorkerTests {
     }
 
     @AfterAll
+    @Timeout(10)
     void stopBroker() {
         broker.stopBroker();
     }

--- a/server/src/test/java/io/opencmw/server/MmiServiceHelperTests.java
+++ b/server/src/test/java/io/opencmw/server/MmiServiceHelperTests.java
@@ -21,10 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.zeromq.Utils;
 import org.zeromq.util.ZData;
 
@@ -40,6 +37,7 @@ class MmiServiceHelperTests {
     private URI brokerAddress;
 
     @BeforeAll
+    @Timeout(10)
     void startBroker() throws IOException {
         broker = new MajordomoBroker(DEFAULT_BROKER_NAME, null, BasicRbacRole.values());
         // broker.setDaemon(true); // use this if running in another app that controls threads
@@ -48,6 +46,7 @@ class MmiServiceHelperTests {
     }
 
     @AfterAll
+    @Timeout(10)
     void stopBroker() {
         broker.stopBroker();
     }


### PR DESCRIPTION
Add some more timeouts. By default there is no timeout on junit's lifecycle methods and they also do not use the `@Timeout`from the class and if they block, the gh actions step will block for the whole 6h and only then report back the cause of the issue.