### PR TITLE
Add command line interface

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
+++ b/client/src/main/java/io/opencmw/client/OpenCmwDataSource.java
@@ -42,7 +42,6 @@ import io.opencmw.filter.SubscriptionMatcher;
 import io.opencmw.serialiser.IoSerialiser;
 import io.opencmw.serialiser.spi.BinarySerialiser;
 import io.opencmw.utils.NoDuplicatesList;
-import io.opencmw.utils.SystemProperties;
 
 /**
  * Client implementation for the OpenCMW protocol.
@@ -145,10 +144,8 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
         socketMonitor.add(Event.CLOSED, Event.CONNECTED, Event.DISCONNECTED);
         socketMonitor.start();
 
-        final long basicHeartBeat = SystemProperties.getValueIgnoreCase(HEARTBEAT, HEARTBEAT_DEFAULT);
-        final long clientTimeOut = SystemProperties.getValueIgnoreCase(CLIENT_TIMEOUT, CLIENT_TIMEOUT_DEFAULT); // [s] N.B. '0' means disabled
         // take the minimum of the (albeit worker) heartbeat, client (if defined) or locally prescribed timeout
-        heartbeatInterval = clientTimeOut == 0 ? Math.min(basicHeartBeat, timeout.toMillis()) : Math.min(Math.min(basicHeartBeat, timeout.toMillis()), TimeUnit.SECONDS.toMicros(clientTimeOut));
+        heartbeatInterval = CLIENT_TIMEOUT == 0 ? Math.min(HEARTBEAT_INTERVAL, timeout.toMillis()) : Math.min(Math.min(HEARTBEAT_INTERVAL, timeout.toMillis()), TimeUnit.SECONDS.toMicros(CLIENT_TIMEOUT));
 
         nextReconnectAttemptTimeStamp = System.currentTimeMillis() + timeout.toMillis();
         final URI reply = connect();
@@ -266,9 +263,9 @@ public class OpenCmwDataSource extends DataSource implements AutoCloseable {
                 dnsWorkerResult.cancel(true);
             }
             dnsWorkerResult = executorService.submit(this::reconnect); // <--- actual reconnect
-            if (reconnectAttempt.getAndIncrement() < SystemProperties.getValueIgnoreCase(RECONNECT_THRESHOLD1, DEFAULT_RECONNECT_THRESHOLD1)) {
+            if (reconnectAttempt.getAndIncrement() < RECONNECT_THRESHOLD1) {
                 nextReconnectAttemptTimeStamp = now + timeout.toMillis();
-            } else if (reconnectAttempt.getAndIncrement() < SystemProperties.getValueIgnoreCase(RECONNECT_THRESHOLD2, DEFAULT_RECONNECT_THRESHOLD2)) {
+            } else if (reconnectAttempt.getAndIncrement() < RECONNECT_THRESHOLD2) {
                 nextReconnectAttemptTimeStamp = now + 10 * timeout.toMillis();
             } else {
                 nextReconnectAttemptTimeStamp = now + 100 * timeout.toMillis();

--- a/client/src/main/java/module-info.java
+++ b/client/src/main/java/module-info.java
@@ -2,7 +2,7 @@ module io.opencmw.client {
     requires disruptor;
     requires io.opencmw;
     requires io.opencmw.serialiser;
-    requires it.unimi.dsi.fastutil;
+    requires it.unimi.dsi.fastutil.core;
     requires java.management;
     requires jeromq;
     requires kotlin.stdlib;

--- a/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
+++ b/client/src/test/java/io/opencmw/client/DnsDataSourceTests.java
@@ -31,6 +31,7 @@ import io.opencmw.OpenCmwConstants;
 import io.opencmw.domain.BinaryData;
 import io.opencmw.domain.NoData;
 import io.opencmw.rbac.BasicRbacRole;
+import io.opencmw.serialiser.spi.Field;
 import io.opencmw.server.MajordomoBroker;
 import io.opencmw.server.MajordomoWorker;
 
@@ -145,10 +146,6 @@ class DnsDataSourceTests {
 
     @Test
     void testWithWorkerStartStopping() throws IOException {
-        DataSource.getFactory(URI.create("mdp:/mmi.dns")).registerDnsResolver(new OpenCmwDnsResolver(dnsBrokerAddress));
-        System.setProperty(OpenCmwConstants.RECONNECT_THRESHOLD1, "10000"); // to reduce waiting time for reconnects
-        System.setProperty(OpenCmwConstants.RECONNECT_THRESHOLD2, "1000"); // to reduce waiting time for reconnects
-
         try (DataSourcePublisher dataSource = new DataSourcePublisher(null, null, "test-client");
                 DataSourcePublisher.Client client = dataSource.getClient()) {
             AtomicInteger notificationCounterA = new AtomicInteger();
@@ -201,7 +198,7 @@ class DnsDataSourceTests {
     @BeforeAll
     @Timeout(10)
     static void init() throws IOException {
-        System.setProperty(OpenCmwConstants.HEARTBEAT, "100"); // to reduce waiting time for changes
+        Field.getField(OpenCmwConstants.class, "HEARTBEAT_INTERVAL").setInt(null, 100); // to reduce waiting time for changes
         dnsBroker = getTestBroker("dnsBroker", "deviceA/property", null);
         dnsBrokerAddress = dnsBroker.bind(URI.create("mdp://*:" + Utils.findOpenPort()));
         openCmwResolver = new OpenCmwDnsResolver(dnsBroker.getContext(), dnsBrokerAddress, Duration.ofMillis(TIMEOUT));
@@ -250,7 +247,7 @@ class DnsDataSourceTests {
                 try {
                     worker.notify(noData, domainData);
                 } catch (Exception e) { // NOPMD
-                    fail("exception in notify");
+                    fail("exception in notify"); // NOSONAR this additional assertion is important because it is tracked
                 }
             }
         }, 0, 100);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>${version.commons-lang3}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.offbytwo</groupId>
+            <artifactId>docopt</artifactId>
+            <version>${version.docopt}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/src/main/java/io/opencmw/OpenCmwConstants.java
+++ b/core/src/main/java/io/opencmw/OpenCmwConstants.java
@@ -2,7 +2,12 @@ package io.opencmw;
 
 import static io.opencmw.OpenCmwProtocol.MdpSubProtocol.PROT_CLIENT;
 
-import java.net.*;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -10,7 +15,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.zeromq.ZMQ;
 
+import io.opencmw.serialiser.annotations.MetaInfo;
+import io.opencmw.utils.Settings;
 import io.opencmw.utils.SystemProperties;
+
+import com.google.auto.service.AutoService;
 
 /**
  * OpenCMW global constant definitions:
@@ -18,7 +27,7 @@ import io.opencmw.utils.SystemProperties;
  * <p>
  * The broker, client and worker are controlled by the following environment variables:
  * <ul>
- * <li> 'OpenCMW.heartBeat' [ms]: default (2500 ms) heart-beat time-out [ms]</li>
+ * <li> 'OpenCMW.heartBeat' [ms]: default (1000 ms) heart-beat time-out [ms]</li>
  * <li> 'OpenCMW.heartBeatLiveness' []: default (3) heart-beat liveness - 3-5 is reasonable
  * <small>N.B. heartbeat expires when last heartbeat message is more than HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS ms ago.
  * this implies also, that worker must either return their message within 'HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS ms'
@@ -30,7 +39,9 @@ import io.opencmw.utils.SystemProperties;
  * <small>N.B. if registered, a HEARTBEAT challenge will be send that needs to be replied with a READY command/re-registering</small></li>
  * </ul>
  */
-public final class OpenCmwConstants {
+@SuppressWarnings("PMD.UseUtilityClass")
+@AutoService(Settings.class)
+public final class OpenCmwConstants implements Settings {
     public static final String WILDCARD = "*";
     public static final String SCHEME_INPROC = "inproc";
     public static final String SCHEME_HTTP = "http";
@@ -38,28 +49,47 @@ public final class OpenCmwConstants {
     public static final String SCHEME_MDP = "mdp";
     public static final String SCHEME_MDS = "mds";
     public static final String SCHEME_TCP = "tcp";
-    public static final String HEARTBEAT = "OpenCMW.heartBeat";
-    public static final long HEARTBEAT_DEFAULT = 1000L;
-    public static final String HEARTBEAT_LIVENESS = "OpenCMW.heartBeatLiveness";
-    public static final int HEARTBEAT_LIVENESS_DEFAULT = 3;
-    public static final String SUBSCRIPTION_TIMEOUT = "OpenCMW.subscriptionTimeOut";
-    public static final long SUBSCRIPTION_TIMEOUT_DEFAULT = 1000L;
-    public static final String N_IO_THREADS = "OpenCMW.nIoThreads";
-    public static final int N_IO_THREADS_DEFAULT = 1; //
-    public static final String HIGH_WATER_MARK = "OpenCMW.hwm";
-    public static final int HIGH_WATER_MARK_DEFAULT = 0; //
-    public static final String CLIENT_TIMEOUT = "OpenCMW.clientTimeOut"; // [s]
-    public static final long CLIENT_TIMEOUT_DEFAULT = 0L; // [s]
-    public static final String DNS_TIMEOUT = "OpenCMW.dnsTimeOut"; // [s]
-    public static final long DNS_TIMEOUT_DEFAULT = 10L; // [s]
     public static final String ADDRESS_GIVEN = "address given: ";
-    public static final String RECONNECT_THRESHOLD1 = "OpenCMW.reconnectThreshold1"; // []
-    public static final int DEFAULT_RECONNECT_THRESHOLD1 = 3; // []
-    public static final String RECONNECT_THRESHOLD2 = "OpenCMW.reconnectThreshold2"; // []
-    public static final int DEFAULT_RECONNECT_THRESHOLD2 = 6; // []
+    /** heart-beat interval in milli-seconds */
+    @MetaInfo(unit = "ms", description = "heart-beat interval in milli-seconds")
+    public static final Integer HEARTBEAT_INTERVAL = 1000;
+    /** heart-beat liveness - 3-5 is reasonable
+     * N.B. heartbeat expires when last heartbeat message is more than 'heartBeat' * 'heartBeatLiveness' ms ago.*/
+    @MetaInfo(unit = "int", description = "heart-beat liveness (3-5 is reasonable)\nN.B. heartbeat expires when last heartbeat message is more than 'heartBeat' * 'heartBeatLiveness' ms ago.")
+    public static final Integer HEARTBEAT_LIVENESS = 3;
+    /** subscription time-out in milli-seconds */
+    @MetaInfo(unit = "ms", description = "subscription time-out in milli-seconds")
+    public static final Integer SUBSCRIPTION_TIMEOUT = 1000;
+    /** number IO threads dedicated to network IO (ZeroMQ recommendation: 1 thread per 1 GBit/s) */
+    @MetaInfo(unit = "int", description = "number IO threads dedicated to network IO (ZeroMQ recommendation: 1 thread per 1 GBit/s)")
+    public static final Integer N_IO_THREADS = 1;
+    /** high-water-mark ie. the number of message frames stored per socket before being dropped */
+    private static final String HWM_DESCRIPTION = //
+            "high-water-mark ie. the number of message frames stored per socket before being dropped\n"
+            + "N.B. '0' implies that the number of frames is only limited by the available memory.\n"
+            + "This is a ZeroMQ tuning parameter. A typical OpenCMW message consists of at least 8-9 frames";
+    //** time-out in seconds after which unanswered client messages are being deleted */
+    @MetaInfo(unit = "<int>", description = HWM_DESCRIPTION)
+    public static final Integer HIGH_WATER_MARK = 0;
+    /** time-out in seconds after which unanswered client messages are being deleted */
+    @MetaInfo(unit = "s", description = "time-out in seconds after which unanswered client messages are being deleted\nN.B. '0' or negative disables this time-out.")
+    public static final Integer CLIENT_TIMEOUT = 0; // [s]
+    /** DNS time-out in seconds after which an unresponsive client is dropped from the DNS table */
+    @MetaInfo(unit = "s", description = "DNS time-out in seconds after which an unresponsive client is dropped from the DNS table\nN.B. if registered, a heart-beat challenge will be send that needs to be replied with a READY command")
+    public static final Integer DNS_TIMEOUT = 10;
+    /** after n1 failed attempts the retry-'heartBeat interval is increased  10-fold */
+    @MetaInfo(unit = "n1", description = "after <n1> failed attempts the retry-'heartBeat interval is increased  10-fold")
+    public static final Integer RECONNECT_THRESHOLD1 = 3;
+    /** after n2 failed attempts the retry-'heartBeat interval is increased 100-fold */
+    @MetaInfo(unit = "n2", description = "after <n2> failed attempts the retry-'heartBeat interval is increased 100-fold")
+    public static final Integer RECONNECT_THRESHOLD2 = 6;
 
-    private OpenCmwConstants() {
-        // this is a utility class
+    static { // init properties with default values given in the description text above
+        init();
+    }
+
+    public static void init() {
+        SystemProperties.addCommandOptions(OpenCmwConstants.class);
     }
 
     public static String getDeviceName(final @NotNull URI endpoint) {
@@ -139,14 +169,12 @@ public final class OpenCmwConstants {
     }
 
     public static void setDefaultSocketParameters(final @NotNull ZMQ.Socket socket) {
-        final int heartBeatInterval = (int) SystemProperties.getValueIgnoreCase(HEARTBEAT, HEARTBEAT_DEFAULT);
-        final int liveness = SystemProperties.getValueIgnoreCase(HEARTBEAT_LIVENESS, HEARTBEAT_LIVENESS_DEFAULT);
-        socket.setHWM(SystemProperties.getValueIgnoreCase(HIGH_WATER_MARK, HIGH_WATER_MARK_DEFAULT));
+        socket.setHWM(HIGH_WATER_MARK);
         socket.setHeartbeatContext(PROT_CLIENT.getData());
-        socket.setHeartbeatTtl(heartBeatInterval * liveness);
-        socket.setHeartbeatTimeout(heartBeatInterval * liveness);
-        socket.setHeartbeatIvl(heartBeatInterval);
-        socket.setLinger(heartBeatInterval);
+        socket.setHeartbeatTtl(HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS);
+        socket.setHeartbeatTimeout(HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS);
+        socket.setHeartbeatIvl(HEARTBEAT_INTERVAL);
+        socket.setLinger(HEARTBEAT_INTERVAL);
     }
 
     public static URI stripPathTrailingSlash(final @NotNull URI address) {

--- a/core/src/main/java/io/opencmw/utils/Settings.java
+++ b/core/src/main/java/io/opencmw/utils/Settings.java
@@ -1,0 +1,21 @@
+package io.opencmw.utils;
+
+/**
+ * Interface used by SystemProperties class to automatically initialises public class field values based on:
+ * * class default value (lowest priority),
+ * * config-file, or
+ * * environment variables (e.g. '-Dxxx' VM argument), or
+ * * command-line arguments (highest priority) being set.
+ * The fields -- if adorned with @see @MetaInfo annotations -- are also used to automatically generate POSIX-inspired
+ * command-line interface usage and options declarations.
+ *
+ *  Beside manually registering the Setting class, you may also want to set the @AutoService(Settings.class) annotation
+ *  to the class in order for other utilities to automatically find the Settings class.
+ *
+ * The field values are set regardless of whether they are static or non-static, and even for 'final' (works only during initialisation)
+ * based on the 'class-name'.'field-name' scheme where are they defined while preserving some level of type-safety.
+ *
+ * E.g. the command-line argument '--MySettings.fieldValue=5' sets the value if 'fieldValue' in class 'MySetting' to 5.
+ */
+public interface Settings {
+}

--- a/core/src/main/java/io/opencmw/utils/SystemProperties.java
+++ b/core/src/main/java/io/opencmw/utils/SystemProperties.java
@@ -2,14 +2,152 @@ package io.opencmw.utils;
 
 import static java.util.Map.Entry;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.docopt.Docopt;
+import org.jetbrains.annotations.NotNull;
+
+import io.opencmw.serialiser.spi.ClassFieldDescription;
 
 public final class SystemProperties { // NOPMD -- nomen est omen
+    protected static final List<String> COMMAND_ARGUMENTS = new NoDuplicatesList<>(); // NOPMD 'protected' needed only for testing purposes
+    protected static final List<Object> COMMAND_OPTION_CLASSES = new NoDuplicatesList<>(); // NOPMD 'protected' needed only for testing purposes
+    private static final String PROGRAM_NAME_TAG = "<program>";
     private static final Properties SYSTEM_PROPERTIES = System.getProperties();
+    private static final String DEFAULT_ARGUMENTS = "  <program> [options]\n";
+    public static String version = "<program version>";
+    private static final Boolean WITH_EXIT = true; // needed only for testing purposes
+
+    static { // init properties with default values given in the description text above
+        parseOptions(new String[0]);
+    }
 
     private SystemProperties() {
         // utility class
+    }
+
+    public static void addCommandArgument(final @NotNull String arguments) {
+        COMMAND_ARGUMENTS.add(arguments);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public static void addCommandOptions(final @NotNull Object definition) {
+        if (COMMAND_OPTION_CLASSES.add(definition)) {
+            SystemProperties.parseOptions(new String[0]);
+        }
+    }
+
+    @SuppressWarnings("PMD.NPathComplexity")
+    public static Map<String, Object> parseOptions(@NotNull final String[] args) {
+        final String commandLineDoc = getCommandLineDoc();
+        final Map<String, Object> opts = new Docopt(commandLineDoc).withExit(WITH_EXIT).withVersion(version).parse(List.of(args)); // NOPMD - no concurrent access
+        final String configFile = Objects.requireNonNull(opts.get("--config"), "corrupt config file name").toString();
+        if (!Boolean.FALSE.equals(opts.get("--help")) && WITH_EXIT) {
+            System.out.println(commandLineDoc);
+            System.exit(0); // NOPMD -- needed once/in case DocOpt is being replaced
+        }
+
+        final Properties configFileProperties = new Properties();
+        try (InputStream input = Files.newInputStream(Paths.get(configFile))) { // N
+            // load a properties file
+            configFileProperties.load(input);
+        } catch (final IOException e) {
+            // to improve: add searching for file in default path, silently continue if this is the missing 'default.cfg' file and throwing an exception otherwise
+            // throw new IllegalArgumentException("config file not readable: '" + configFile + "'", e)
+        }
+
+        final ConcurrentHashMap<String, Object> retMap = new ConcurrentHashMap<>();
+        for (Object optionClass : COMMAND_OPTION_CLASSES) {
+            final ClassFieldDescription classDescription = new ClassFieldDescription((optionClass instanceof Class) ? (Class<?>) optionClass : optionClass.getClass(), true); // NOPMD
+            final String configClassName = classDescription.getTypeNameSimple();
+            classDescription.getChildren().stream().map(ClassFieldDescription.class ::cast).forEach(field -> {
+                final String environmentOption = configClassName + '.' + field.getFieldName();
+                String stringValue = null;
+                // default values taken form class definition -- lowest priority
+
+                // passing config file option
+                if (configFileProperties.get(environmentOption) != null) {
+                    stringValue = configFileProperties.get(environmentOption).toString();
+                }
+
+                // passing JVM environment Variables
+                if (SYSTEM_PROPERTIES.get(environmentOption) != null) {
+                    stringValue = SYSTEM_PROPERTIES.get(environmentOption).toString();
+                }
+
+                // passing command-line options -- highest priority
+                final String commandLineOption = "--" + environmentOption;
+                if (opts.get(commandLineOption) != null) {
+                    final Object value = opts.get(commandLineOption);
+                    // found matching field
+                    stringValue = (value instanceof List ? ((List<?>) value).get(0) : value).toString();
+                }
+                // perform actual setting of settings
+                if (stringValue != null) {
+                    field.getField().set(optionClass, stringValue);
+                    SystemProperties.put(environmentOption, stringValue);
+                    retMap.put(environmentOption, stringValue);
+                }
+            });
+        }
+
+        return retMap;
+    }
+
+    public static String getCommandLineDoc() {
+        for (final Settings settingClass : ServiceLoader.load(Settings.class)) {
+            // enable this for testing
+            // System.err.println("found settingClass " + settingClass)
+            COMMAND_OPTION_CLASSES.add(settingClass);
+        }
+
+        final StringBuilder builder = new StringBuilder(1000);
+        builder.append("Usage:\n").append(String.join("", COMMAND_ARGUMENTS)).append(DEFAULT_ARGUMENTS).append("\nOptions:\n");
+
+        final List<String[]> descriptionItems = new ArrayList<>();
+        for (Object optionClass : COMMAND_OPTION_CLASSES) {
+            final ClassFieldDescription classDescription = new ClassFieldDescription((optionClass instanceof Class) ? (Class<?>) optionClass : optionClass.getClass(), true); // NOPMD
+            final String configClassName = classDescription.getTypeNameSimple();
+            classDescription.getChildren().stream().map(ClassFieldDescription.class ::cast).filter(f -> f.isPublic() && f.isAnnotationPresent()).forEach(field -> {
+                final String commandLineOption = "--" + configClassName + '.' + field.getFieldName();
+                final String[] propertyDescription = new String[3]; // NOPMD - dynamic in loop generation needed
+                propertyDescription[0] = commandLineOption + "=<" + field.getFieldUnit() + '>';
+                propertyDescription[1] = "[default: " + field.getField().get(optionClass) + "]";
+                propertyDescription[2] = field.getFieldDescription();
+                descriptionItems.add(propertyDescription);
+            });
+        }
+        // add default optional parameters
+        descriptionItems.add(new String[] { "", "", "" }); // empty line on purpose
+        descriptionItems.add(new String[] { "-c FILE --config=FILE", "[default: default.cfg]", "load properties from file." });
+        descriptionItems.add(new String[] { "-p --print", "", "print actual parsed/provided parameters." });
+        descriptionItems.add(new String[] { "-h --help", "", "show this screen." });
+        descriptionItems.add(new String[] { "--version", "", "show version." });
+
+        final int longestArg = descriptionItems.stream().mapToInt(s -> s[0].length()).max().orElse(0) + 2;
+        final int longestUnit = descriptionItems.stream().mapToInt(s -> s[1].length()).max().orElse(0);
+        for (String[] line : descriptionItems) {
+            boolean first = true;
+            for (String description : StringUtils.split(line[2], "\n")) {
+                builder.append(String.format("  %-" + longestArg + "s %-" + longestUnit + "s %s\n", first ? line[0] : "", first ? line[1] : "", description));
+                first = false;
+            }
+        }
+
+        final String programName = StringUtils.split(Objects.requireNonNullElse(System.getProperty("sun.java.command"), PROGRAM_NAME_TAG), " ")[0];
+        return StringUtils.replace(builder.toString(), PROGRAM_NAME_TAG, programName);
     }
 
     public static String getProperty(final String key) {
@@ -44,6 +182,18 @@ public final class SystemProperties { // NOPMD -- nomen est omen
     public static int getValue(String key, int defaultValue) {
         final String value = getProperty(key);
         return value == null ? defaultValue : Integer.parseInt(value);
+    }
+
+    public static int getIntValueIgnoreCase(String key) {
+        return Integer.parseInt(Objects.requireNonNull(getPropertyIgnoreCase(key), "value null for key: " + key));
+    }
+
+    public static long getLongValueIgnoreCase(String key) {
+        return Long.parseLong(Objects.requireNonNull(getPropertyIgnoreCase(key), "value null for key: " + key));
+    }
+
+    public static double getDoubleValueIgnoreCase(String key) {
+        return Double.parseDouble(Objects.requireNonNull(getPropertyIgnoreCase(key), "value null for key: " + key));
     }
 
     public static double getValueIgnoreCase(String key, double defaultValue) {

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 open module io.opencmw {
+    uses io.opencmw.utils.Settings;
+    requires com.google.auto.service;
     requires disruptor;
     requires org.slf4j;
     requires jeromq;
@@ -6,6 +8,7 @@ open module io.opencmw {
     requires org.apache.commons.lang3;
     requires org.jetbrains.annotations;
     requires jsoniter;
+    requires docopt;
 
     exports io.opencmw;
     exports io.opencmw.domain;

--- a/core/src/test/java/io/opencmw/utils/SystemPropertiesTest.java
+++ b/core/src/test/java/io/opencmw/utils/SystemPropertiesTest.java
@@ -1,0 +1,111 @@
+package io.opencmw.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static io.opencmw.utils.SystemProperties.parseOptions;
+
+import java.util.Map;
+
+import org.docopt.DocoptExitException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opencmw.serialiser.annotations.MetaInfo;
+import io.opencmw.serialiser.spi.Field;
+
+class SystemPropertiesTest {
+    @BeforeEach
+    void init() {
+        // re-initialise properties before each test
+        SystemProperties.put("testString", "test");
+        SystemProperties.put("testInt", "42");
+        SystemProperties.put("testLong", "43");
+        SystemProperties.put("testDouble", "44.0");
+    }
+
+    @SuppressWarnings("InstantiationOfUtilityClass")
+    @Test
+    void testCommandLineOptions() {
+        Field.getField(SystemProperties.class, "WITH_EXIT").setBoolean(null, false); // needed only for testing purposes
+
+        final Map<String, Object> ret = parseOptions(new String[0]);
+        assertNotNull(ret);
+        assertFalse(ret.isEmpty());
+
+        try {
+            parseOptions(new String[] { "--version" });
+            fail();
+        } catch (DocoptExitException e) {
+            assertEquals(SystemProperties.version, e.getMessage());
+        }
+
+        assertThrows(DocoptExitException.class, () -> parseOptions(new String[] { "-h" }));
+        assertThrows(DocoptExitException.class, () -> parseOptions(new String[] { "-help" }));
+
+        final String testCommand = "  <program> myCommand [options] command documentation\n";
+        SystemProperties.addCommandArgument(testCommand);
+
+        SystemProperties.addCommandOptions(new TestOptionClass());
+        // uncomment for testing:
+        // System.err.println(SystemProperties.getCommandLineDoc())
+        try {
+            parseOptions(new String[] { "-help" });
+            fail();
+        } catch (DocoptExitException e) {
+            assertTrue(e.getMessage().contains(testCommand.split("<program>")[1]));
+            assertTrue(e.getMessage().contains(TestOptionClass.TEST_OPTION_DOC));
+        }
+
+        final String option = "SystemPropertiesTest$TestOptionClass.TEST_OPTION";
+        assertEquals(42, Integer.parseInt(parseOptions(new String[] { "--" + option + "=42" }).get(option).toString()));
+        assertEquals(42, SystemProperties.getIntValueIgnoreCase(option));
+
+        assertEquals(43, Integer.parseInt(parseOptions(new String[] { "--" + option + "=43" }).get(option).toString()));
+        assertEquals(43, SystemProperties.getIntValueIgnoreCase(option));
+
+        SystemProperties.COMMAND_ARGUMENTS.clear();
+        SystemProperties.COMMAND_OPTION_CLASSES.clear();
+        // uncomment for testing:
+        try {
+            parseOptions(new String[] { "-help" });
+            fail();
+        } catch (DocoptExitException e) {
+            assertFalse(e.getMessage().contains(testCommand));
+            assertFalse(e.getMessage().contains(TestOptionClass.TEST_OPTION_DOC));
+        }
+
+        Field.getField(SystemProperties.class, "WITH_EXIT").setBoolean(null, true); // needed only for testing purposes
+    }
+
+    private static class TestOptionClass {
+        public static final String TEST_OPTION_DOC = "TestOptionClass.TEST_OPTION=<int>";
+        @MetaInfo(unit = "int", description = "test option documentation")
+        public static final Integer TEST_OPTION = 0;
+    }
+
+    @Test
+    void getProperty() {
+        assertNotNull(SystemProperties.getProperty("testString"));
+        assertEquals(SystemProperties.getPropertyIgnoreCase("testString"), SystemProperties.getPropertyIgnoreCase("TESTSTRING"));
+        assertEquals(SystemProperties.getPropertyIgnoreCase("testInt"), SystemProperties.getPropertyIgnoreCase("TESTINT"));
+        assertEquals(SystemProperties.getPropertyIgnoreCase("testLong"), SystemProperties.getPropertyIgnoreCase("TESTLONG"));
+        assertEquals(SystemProperties.getPropertyIgnoreCase("testDouble"), SystemProperties.getPropertyIgnoreCase("TESTDOUBLE"));
+        assertNull(SystemProperties.getPropertyIgnoreCase("unknownProperty"));
+    }
+
+    @Test
+    void getValue() {
+        assertEquals(SystemProperties.getValue("testInt", 1), SystemProperties.getValueIgnoreCase("TESTINT", 3));
+        assertEquals(SystemProperties.getValue("testLong", 1), SystemProperties.getValueIgnoreCase("TESTLONG", 3L));
+        assertEquals(SystemProperties.getValue("testDouble", 1.0), SystemProperties.getValueIgnoreCase("TESTDOUBLE", 3.0));
+        assertEquals(SystemProperties.getValue("testInt", 1), SystemProperties.getIntValueIgnoreCase("TESTINT"));
+        assertEquals(SystemProperties.getValue("testLong", 1), SystemProperties.getLongValueIgnoreCase("TESTLONG"));
+        assertEquals(SystemProperties.getValue("testDouble", 1.0), SystemProperties.getDoubleValueIgnoreCase("TESTDOUBLE"));
+    }
+
+    @Test
+    void put() {
+        assertDoesNotThrow(() -> SystemProperties.put("testKey", "testValue"));
+        assertEquals("testValue", SystemProperties.getProperty("testKey"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.slf4j>2.0.0-alpha0</version.slf4j>
+        <version.auto-service>1.0-rc7</version.auto-service>
         <version.jetbrains.annotations>20.1.0</version.jetbrains.annotations>
         <version.jeromq>0.5.2</version.jeromq>
         <versions.lmax.disruptor>3.4.2</versions.lmax.disruptor>
@@ -46,6 +47,7 @@
         <version.micrometer>1.6.5</version.micrometer>
         <version.velocity>2.3</version.velocity>
         <version.chartfx>11.2.5</version.chartfx>
+        <version.docopt>0.6.0.20150202</version.docopt>
     </properties>
 
     <licenses>
@@ -103,6 +105,13 @@
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.service</groupId>
+                            <artifactId>auto-service</artifactId>
+                            <version>${version.auto-service}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -229,6 +238,12 @@
             <artifactId>annotations</artifactId>
             <version>${version.jetbrains.annotations}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>${version.auto-service}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
         <version.javalin>3.13.4</version.javalin>
         <version.jetty>9.4.35.v20201120</version.jetty> <!-- N.B. needs to be synchronised/tested with Javalin version -->
         <version.jsoniter>0.9.23</version.jsoniter>
-        <version.fastutil>8.5.2</version.fastutil>
+        <version.fastutil>8.5.4</version.fastutil>
         <version.javassist>3.27.0-GA</version.javassist>
         <version.okHttp3>4.9.1</version.okHttp3>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.jupiter>5.7.1</version.jupiter>
         <version.awaitility>4.0.3</version.awaitility>
         <version.JMemoryBuddy>0.5.0</version.JMemoryBuddy>
-        <version.jmh>1.28</version.jmh>
+        <version.jmh>1.29</version.jmh>
         <version.micrometer>1.6.5</version.micrometer>
         <version.velocity>2.3</version.velocity>
         <version.chartfx>11.2.5</version.chartfx>

--- a/serialiser/pom.xml
+++ b/serialiser/pom.xml
@@ -26,7 +26,7 @@
         <!-- serialiser dependencies -->
         <dependency> <!-- somehow needed for running the tests. -->
             <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
+            <artifactId>fastutil-core</artifactId>
             <version>${version.fastutil}</version>
         </dependency>
         <dependency>

--- a/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,8 +23,6 @@ import io.opencmw.serialiser.annotations.MetaInfo;
 import io.opencmw.serialiser.annotations.Unit;
 import io.opencmw.serialiser.utils.ClassUtils;
 
-import sun.misc.Unsafe; // NOPMD NOSONAR - there is nothing more suitable under the Sun
-
 /**
  * @author rstein
  */
@@ -30,7 +30,7 @@ import sun.misc.Unsafe; // NOPMD NOSONAR - there is nothing more suitable under 
 public class ClassFieldDescription implements FieldDescription {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClassFieldDescription.class);
     private final int hierarchyDepth;
-    private final FieldAccess fieldAccess;
+    private final Field field;
     private final String fieldName;
     private final int fieldNameHashCode;
     private final String fieldNameRelative;
@@ -100,15 +100,7 @@ public class ClassFieldDescription implements FieldDescription {
         this.parent = parent;
 
         if (referenceClass == null) {
-            if (field == null) {
-                throw new IllegalArgumentException("field must not be null");
-            }
-            try {
-                fieldAccess = new FieldAccess(field);
-            } catch (final Exception e) { //NOPMD NOSONAR
-                LOGGER.atError().addArgument(field.getName()).addArgument(parent).log("error initialising field '{}' (parent: {})");
-                throw e;
-            }
+            this.field = Objects.requireNonNull(field, "field must not be null");
             classType = field.getType();
             fieldNameHashCode = field.getName().hashCode();
             fieldName = field.getName().intern();
@@ -117,7 +109,7 @@ public class ClassFieldDescription implements FieldDescription {
             modifierID = field.getModifiers();
             dataType = DataType.fromClassType(classType);
         } else {
-            fieldAccess = null; // it's a root, no field definition available
+            this.field = null; // NOPMD it's a root, no field definition available
             classType = referenceClass;
             fieldNameHashCode = classType.getName().hashCode();
             fieldName = classType.getName().intern();
@@ -175,17 +167,8 @@ public class ClassFieldDescription implements FieldDescription {
      * @param fullScan {@code true} if the class field should be serialised according to {@link java.io.Serializable}
      *        (ie. object's non-static and non-transient fields); {@code false} otherwise.
      */
-    public ClassFieldDescription(final Field field, final ClassFieldDescription parent, final int recursionLevel,
-            final boolean fullScan) {
+    public ClassFieldDescription(@NotNull final Field field, final ClassFieldDescription parent, final int recursionLevel, final boolean fullScan) {
         this(null, field, parent, recursionLevel);
-        if (field == null) {
-            throw new IllegalArgumentException("field must not be null");
-        }
-
-        if (serializable) {
-            // enable access by default (saves performance later on)
-            field.setAccessible(true); // NOSONAR NOPMD
-        }
 
         // add child to parent if it serializable or if a full scan is requested
         if (this.parent != null && (serializable || fullScan)) {
@@ -243,6 +226,7 @@ public class ClassFieldDescription implements FieldDescription {
     public FieldDescription findChildField(final int fieldNameHashCode, final String fieldName) {
         for (final FieldDescription child : children) {
             final String name = child.getFieldName();
+            //noinspection StringEquality
             if (name == fieldName) { //NOSONAR NOPMD early return if the same String object reference
                 return child;
             }
@@ -271,7 +255,7 @@ public class ClassFieldDescription implements FieldDescription {
     public List<Type> getActualTypeArguments() {
         if (genericTypeList == null) {
             genericTypeList = new ArrayList<>();
-            if ((fieldAccess == null) || (getGenericType() == null) || !(getGenericType() instanceof ParameterizedType)) {
+            if ((field == null) || (getGenericType() == null) || !(getGenericType() instanceof ParameterizedType)) {
                 return genericTypeList;
             }
             genericTypeList.addAll(Arrays.asList(((ParameterizedType) getGenericType()).getActualTypeArguments()));
@@ -312,10 +296,17 @@ public class ClassFieldDescription implements FieldDescription {
     }
 
     /**
+     * @return possible Enum definitions, see also 'isEnum()'
+     */
+    public List<?> getEnumConstants() {
+        return enumDefinitions;
+    }
+
+    /**
      * @return the underlying Field type or {@code null} if it's a root node
      */
-    public FieldAccess getField() {
-        return fieldAccess;
+    public Field getField() {
+        return field;
     }
 
     @Override
@@ -402,12 +393,12 @@ public class ClassFieldDescription implements FieldDescription {
 
     public Type getGenericType() {
         if (genericType == null) {
-            genericType = fieldAccess == null ? new Type() {
+            genericType = field == null ? new Type() {
                 @Override
                 public String getTypeName() {
                     return "unknown type";
                 }
-            } : fieldAccess.field.getGenericType();
+            } : field.getGenericType();
         }
         return genericType;
     }
@@ -513,13 +504,6 @@ public class ClassFieldDescription implements FieldDescription {
      */
     public boolean isEnum() {
         return isEnumType;
-    }
-
-    /**
-     * @return possible Enum definitions, see also 'isEnum()'
-     */
-    public List<?> getEnumConstants() {
-        return enumDefinitions;
     }
 
     /**
@@ -657,11 +641,11 @@ public class ClassFieldDescription implements FieldDescription {
         }
 
         // loop over member fields and inner classes
-        for (final Field pfield : classType.getDeclaredFields()) {
+        Arrays.stream(classType.getDeclaredFields()).map(Field::new).forEach(pfield -> {
             final FieldDescription localParent = parent.getParent();
             if ((localParent != null && pfield.getType().equals(localParent.getType()) && recursionLevel >= ClassUtils.getMaxRecursionDepth()) || pfield.getName().startsWith("this$")) {
                 // inner classes contain parent as part of declared fields
-                continue;
+                return;
             }
             final ClassFieldDescription field = new ClassFieldDescription(pfield, parent, recursionLevel + 1, fullScan); // NOPMD
             // N.B. unavoidable in-loop object generation
@@ -674,7 +658,7 @@ public class ClassFieldDescription implements FieldDescription {
                 // object is a (technically) Serializable, unknown (ie 'OTHER) compound object or interface than can be further parsed
                 exploreClass(ClassUtils.getRawType(field.getType()), field, recursionLevel + 1, fullScan);
             }
-        }
+        });
     }
 
     protected static void printClassStructure(final ClassFieldDescription field, final boolean fullView, final int recursionLevel) {
@@ -758,104 +742,5 @@ public class ClassFieldDescription implements FieldDescription {
 
     private static String spaces(final int spaces) {
         return CharBuffer.allocate(spaces).toString().replace('\0', ' ');
-    }
-
-    public static class FieldAccess {
-        private static final Unsafe unsafe; // NOPMD
-
-        static {
-            // get an instance of the otherwise private 'Unsafe' class
-            try {
-                final Field field = Unsafe.class.getDeclaredField("theUnsafe");
-                field.setAccessible(true); // NOSONAR NOPMD
-                unsafe = (Unsafe) field.get(null);
-            } catch (NoSuchFieldException | SecurityException | IllegalAccessException e) { // NOPMD
-                throw new SecurityException(e); // NOPMD
-            }
-        }
-
-        private final Field field;
-        private final long fieldByteOffset;
-
-        private FieldAccess(final Field field) {
-            this.field = field;
-            field.setAccessible(true); //NOSONAR
-
-            long offset = -1;
-            try {
-                offset = unsafe.objectFieldOffset(field);
-            } catch (IllegalArgumentException e) {
-                // fails for private static final fields
-            }
-            this.fieldByteOffset = offset;
-        }
-
-        public Object get(final Object classReference) {
-            return unsafe.getObject(classReference, fieldByteOffset);
-        }
-
-        public boolean getBoolean(final Object classReference) {
-            return unsafe.getBoolean(classReference, fieldByteOffset);
-        }
-
-        public byte getByte(final Object classReference) {
-            return unsafe.getByte(classReference, fieldByteOffset);
-        }
-
-        public char getChar(final Object classReference) {
-            return unsafe.getChar(classReference, fieldByteOffset);
-        }
-
-        public double getDouble(final Object classReference) {
-            return unsafe.getDouble(classReference, fieldByteOffset);
-        }
-
-        public Field getField() {
-            return field;
-        }
-        public float getFloat(final Object classReference) {
-            return unsafe.getFloat(classReference, fieldByteOffset);
-        }
-        public int getInt(final Object classReference) {
-            return unsafe.getInt(classReference, fieldByteOffset);
-        }
-        public long getLong(final Object classReference) {
-            return unsafe.getLong(classReference, fieldByteOffset);
-        }
-        public short getShort(final Object classReference) { // NOPMD
-            return unsafe.getShort(classReference, fieldByteOffset);
-        }
-        public void set(final Object classReference, final Object obj) {
-            unsafe.putObject(classReference, fieldByteOffset, obj);
-        }
-        public void setBoolean(final Object classReference, final boolean value) {
-            unsafe.putBoolean(classReference, fieldByteOffset, value);
-        }
-        public void setByte(final Object classReference, final byte value) {
-            unsafe.putByte(classReference, fieldByteOffset, value);
-        }
-        public void setChar(final Object classReference, final char value) {
-            unsafe.putChar(classReference, fieldByteOffset, value);
-        }
-
-        public void setDouble(final Object classReference, final double value) {
-            unsafe.putDouble(classReference, fieldByteOffset, value);
-        }
-
-        public void setFloat(final Object classReference, final float value) {
-            unsafe.putFloat(classReference, fieldByteOffset, value);
-        }
-
-        public void setInt(final Object classReference, final int value) {
-            unsafe.putInt(classReference, fieldByteOffset, value);
-        }
-
-        public void setLong(final Object classReference, final long value) {
-            unsafe.putLong(classReference, fieldByteOffset, value);
-        }
-
-        public void setShort(final Object classReference, final short value) { // NOPMD
-            unsafe.putShort(classReference, fieldByteOffset, value);
-        }
     }
 }

--- a/serialiser/src/main/java/io/opencmw/serialiser/spi/Field.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/spi/Field.java
@@ -1,0 +1,522 @@
+package io.opencmw.serialiser.spi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import org.jetbrains.annotations.NotNull;
+
+import sun.misc.Unsafe; // NOPMD NOSONAR - there is nothing better under the Sun
+
+/**
+ * Reflection-based direct access methods to Fields including those w/o necessary direct access from standard user-code.
+ *
+ * <p> N.B. While this can be (mis-)used in user-level code, this is primarily intended for library-use and performance related code
+ * that needs to access protected fields e.g. in view of unit-tests, serialiser or cleaner/simpler static class initialisation.
+ */
+@SuppressWarnings("PMD") // purposeful reflection-based accesses, safe/tested use of direct memory access (via Unsafe class), 'short' primitive handling, etc.
+public class Field implements AnnotatedElement {
+    private static final Unsafe unsafe;
+    static {
+        // get an instance of the otherwise private 'Unsafe' class
+        try {
+            final java.lang.reflect.Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true); // NOSONAR
+            unsafe = (Unsafe) field.get(null);
+        } catch (NoSuchFieldException | SecurityException | IllegalAccessException e) {
+            throw new SecurityException(e);
+        }
+    }
+    private static final Field STRING_FIELD_VALUE = getField(String.class, "value");
+    private static final Field STRING_FIELD_HASH = getField(String.class, "hash");
+    private final java.lang.reflect.Field jdkField;
+    private final Object staticBase;
+    private final long fieldByteOffset;
+    private final boolean invalidTypeCombination;
+    private final String exceptionMessage;
+    private final boolean primitive;
+    private final Type genericType;
+    private Annotation[] declaredAnnotations;
+
+    Field(final java.lang.reflect.Field jdkField) {
+        exceptionMessage = "cannot set static final primitive-typed variable " + jdkField.getType() + " " + jdkField.getName();
+        this.jdkField = jdkField;
+        this.genericType = jdkField.getGenericType();
+        primitive = jdkField.getType().isPrimitive();
+        invalidTypeCombination = isStatic() && isFinal() && primitive;
+
+        if (isStatic()) {
+            this.staticBase = unsafe.staticFieldBase(jdkField);
+            this.fieldByteOffset = unsafe.staticFieldOffset(jdkField);
+        } else {
+            this.staticBase = null;
+            this.fieldByteOffset = unsafe.objectFieldOffset(jdkField);
+        }
+    }
+
+    /**
+     * Generic access to field values for a given class instance reference.
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @return the value object contained by this field. Primitives are automatically boxed.
+     */
+    public Object get(final Object classReference) {
+        if (isPrimitive()) {
+            if (getType() == boolean.class) {
+                return getBoolean(classReference);
+            } else if (getType() == byte.class) {
+                return getByte(classReference);
+            } else if (getType() == char.class) {
+                return getChar(classReference);
+            } else if (getType() == short.class) {
+                return getShort(classReference);
+            } else if (getType() == int.class) {
+                return getInt(classReference);
+            } else if (getType() == long.class) {
+                return getLong(classReference);
+            } else if (getType() == float.class) {
+                return getFloat(classReference);
+            } else if (getType() == double.class) {
+                return getDouble(classReference);
+            }
+        }
+        return unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public boolean getBoolean(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getBoolean(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (boolean) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public byte getByte(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getByte(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (byte) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public char getChar(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getChar(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (char) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @return the {@code Class} object representing the class or interface that declares this {@code Field} object.
+     */
+    public final Class<?> getDeclaringClass() {
+        return jdkField.getDeclaringClass();
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public double getDouble(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getDouble(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (double) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     *
+     * @return the JDK-based field description
+     * @deprecated shouldn't ideally be used in end-user-code and restraint to well-tested/encapsulated library code
+     */
+    @Deprecated(since = "do no use direct access to reflection but the other equivalent direct methods")
+    public final java.lang.reflect.Field getJdkField() {
+        return jdkField;
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public float getFloat(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getFloat(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (float) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @return {@code Type} object that represents the declared type for this {@code Field} object.
+     *
+     * <p>If the {@code Type} is a parameterized type, the {@code Type} object returned must accurately reflect the
+     * actual type parameters used in the source code.
+     *
+     * <p>If the type of the underlying field is a type variable or a parameterized type, it is created. Otherwise, it is resolved.
+     */
+    public final Type getGenericType() {
+        return genericType;
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public int getInt(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getInt(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (int) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public long getLong(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getLong(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (long) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /**
+     * @return the Java language modifiers for the field represented by this {@code Field} object, as an integer.
+     * The {@code Modifier} class should be used to decode the modifiers.
+     */
+    public final int getModifiers() {
+        return jdkField.getModifiers();
+    }
+
+    /**
+     * @return the name of the field represented by this {@code Field} object.
+     */
+    public final String getName() {
+        return jdkField.getName();
+    }
+
+    /**
+     * @param classReference class instance the data should be retrieved for.
+     * @return the primitive value the field is pointing to for a given {@code classReference} instance.
+     */
+    public short getShort(final Object classReference) {
+        if (isPrimitive()) {
+            return unsafe.getShort(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        } else {
+            return (short) unsafe.getObject(staticBase == null ? classReference : staticBase, fieldByteOffset);
+        }
+    }
+
+    /** @return {@code Class} object that identifies the declared type for this {@code Field} object. */
+    public final Class<?> getType() {
+        return jdkField.getType();
+    }
+
+    /** @return {@code true} if the field is defined with the {@code abstract} modifier, {@code false} otherwise. */
+    public final boolean isAbstract() {
+        return Modifier.isAbstract(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code final} modifier, {@code false} otherwise. */
+    public final boolean isFinal() {
+        return Modifier.isFinal(jdkField.getModifiers());
+    }
+
+    /** @return @return {@code true} if the field is defined with the {@code native} modifier, {@code false} otherwise. */
+    public final boolean isNative() {
+        return Modifier.isNative(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code private} modifier, {@code false} otherwise. */
+    public final boolean isPackagePrivate() {
+        return !isPrivate() && !isProtected() && !isPublic();
+    }
+
+    /** @return {@code true} if the field is a primitive (e.g. boolean, int, .., float, double value, {@code false} otherwise. */
+    public final boolean isPrimitive() {
+        return primitive;
+    }
+
+    /** @return {@code true} if the field is defined with the {@code private} modifier, {@code false} otherwise. */
+    public final boolean isPrivate() {
+        return Modifier.isPrivate(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code protected} modifier, {@code false} otherwise. */
+    public final boolean isProtected() {
+        return Modifier.isProtected(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code public} modifier, {@code false} otherwise. */
+    public final boolean isPublic() {
+        return Modifier.isPublic(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code static} modifier, {@code false} otherwise. */
+    public final boolean isStatic() {
+        return Modifier.isStatic(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code strictfp} modifier, {@code false} otherwise. */
+    public final boolean isStrict() {
+        return Modifier.isStrict(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code synchronised} modifier, {@code false} otherwise. */
+    public final boolean isSynchronized() {
+        return Modifier.isSynchronized(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code transient} modifier, {@code false} otherwise. */
+    public final boolean isTransient() {
+        return Modifier.isTransient(jdkField.getModifiers());
+    }
+
+    /** @return {@code true} if the field is defined with the {@code volatile} modifier, {@code false} otherwise. */
+    public final boolean isVolatile() {
+        return Modifier.isVolatile(jdkField.getModifiers());
+    }
+
+    /**
+     * Stores a reference Object value into a given Java variable.
+     *
+     * @param classReference classReference class instance the data should be retrieved for.
+     * @param obj the Object value the field is pointing to for a given {@code classReference} instance.
+     */
+    public void set(final Object classReference, final Object obj) {
+        unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, obj);
+    }
+
+    /**
+     * Convert a String value and stores the result into a given Java variable.
+     * Supported are Strings, primitive and boxed Numbers
+     *
+     * @param classReference classReference class instance the data should be retrieved for.
+     * @param srcString the string to be converted to the field value.
+     * @throws NumberFormatException if the string does not contain a parsable number.
+     * @throws IllegalArgumentException if string cannot be converted to the field type.
+     */
+    public void set(final Object classReference, @NotNull final String srcString) { // NOSONAR - complexity is inherent to lack of generics for primitive types
+        final Class<?> type = getType();
+        if (type == String.class) {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, srcString);
+            return;
+        }
+        try {
+            if (type == boolean.class || type == Boolean.class) {
+                setBoolean(classReference, Boolean.parseBoolean(srcString));
+                return;
+            } else if (type == byte.class || type == Byte.class) {
+                setByte(classReference, Byte.parseByte(srcString));
+                return;
+            } else if (type == char.class || type == Character.class) {
+                setChar(classReference, srcString.isBlank() ? 0 : srcString.charAt(0));
+                return;
+            } else if (type == short.class || type == Short.class) {
+                setShort(classReference, Short.parseShort(srcString));
+                return;
+            } else if (type == int.class || type == Integer.class) {
+                setInt(classReference, Integer.parseInt(srcString));
+                return;
+            } else if (type == long.class || type == Long.class) {
+                setLong(classReference, Long.parseLong(srcString));
+                return;
+            } else if (type == float.class || type == Float.class) {
+                setFloat(classReference, Float.parseFloat(srcString));
+                return;
+            } else if (type == double.class || type == Double.class) {
+                setDouble(classReference, Double.parseDouble(srcString));
+                return;
+            }
+        } catch (NumberFormatException e) {
+            throw new NumberFormatException("cannot cast String '" + srcString + "' to field type '" + type + "' of " + this.getName());
+        }
+        throw new IllegalArgumentException("cannot cast String '" + srcString + "' to field type '" + type + "' of " + this.getName());
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setBoolean(final Object classReference, final boolean value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putBoolean(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setByte(final Object classReference, final byte value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putByte(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setChar(final Object classReference, final char value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putChar(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setDouble(final Object classReference, final double value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putDouble(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setFloat(final Object classReference, final float value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putFloat(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setInt(final Object classReference, final int value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putInt(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setLong(final Object classReference, final long value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putLong(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    /**
+     * Sets primitive or boxed value to field for a given {@code classReference}
+     *
+     * @param classReference class instance the data should be retrieved for.
+     * @param value the primitive value to be set.
+     */
+    public void setShort(final Object classReference, final short value) {
+        if (isPrimitive()) {
+            guardAgainstIllegalStaticFinalPrimitiveAccess();
+            unsafe.putShort(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        } else {
+            unsafe.putObject(staticBase == null ? classReference : staticBase, fieldByteOffset, value);
+        }
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(@NotNull final Class<T> annotationClass) {
+        return jdkField.getAnnotation(annotationClass);
+    }
+
+    @Override
+    public final Annotation[] getAnnotations() {
+        return getDeclaredAnnotations();
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        if (declaredAnnotations == null) {
+            declaredAnnotations = jdkField.getDeclaredAnnotations();
+        }
+        return declaredAnnotations;
+    }
+
+    /**
+     * @throws IllegalArgumentException in case the field is of a static final primitive-type (N.B. this are inlined/truly hardcoded by the java compiler
+     */
+    private void guardAgainstIllegalStaticFinalPrimitiveAccess() {
+        if (invalidTypeCombination) {
+            throw new IllegalArgumentException(exceptionMessage);
+        }
+    }
+
+    public static Field getField(@NotNull final Class<?> clazz, @NotNull final String fieldName) {
+        try {
+            return new Field(clazz.getDeclaredField(fieldName));
+        } catch (NoSuchFieldException e) {
+            throw new IllegalArgumentException("class " + clazz + " does not contain field named '" + fieldName + "'", e);
+        }
+    }
+
+    /**
+     * Resets the internal value and hash of String. This is useful for globally unique String parameter or to
+     * reset Strings that may contain, for example, plain-text passwords that otherwise could be recuperated via the gc.
+     *
+     * @param oldString the old String handle (should be globally unique)
+     * @param newValue the new String value
+     */
+    public static void resetString(@NotNull final String oldString, @NotNull final String newValue) {
+        final byte[] newValueBytes = newValue.getBytes(StandardCharsets.UTF_8);
+        STRING_FIELD_VALUE.set(oldString, newValueBytes);
+        STRING_FIELD_HASH.setInt(oldString, 0); // forces to recompute hash once needed
+    }
+}

--- a/serialiser/src/main/java/module-info.java
+++ b/serialiser/src/main/java/module-info.java
@@ -3,8 +3,8 @@ module io.opencmw.serialiser {
     requires org.slf4j;
     requires jsoniter;
     requires jdk.unsupported;
-    requires it.unimi.dsi.fastutil;
     requires org.jetbrains.annotations;
+    requires it.unimi.dsi.fastutil.core;
 
     exports io.opencmw.serialiser;
     exports io.opencmw.serialiser.annotations;

--- a/serialiser/src/test/java/io/opencmw/serialiser/spi/FieldTest.java
+++ b/serialiser/src/test/java/io/opencmw/serialiser/spi/FieldTest.java
@@ -1,0 +1,390 @@
+package io.opencmw.serialiser.spi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.opencmw.serialiser.annotations.MetaInfo;
+
+/**
+ * Tests reflection related access to Fields w/o necessary direct access. N.B. this is intended for library-use only.
+ */
+@SuppressWarnings("PMD") // many assertions, 'short' primitive accesses, etc.
+class FieldTest {
+    @Test
+    void testFieldAccess() {
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(Field.class, "333"));
+        assertNotNull(Field.getField(Field.class, "unsafe"));
+        final String testFieldName = "PUBLIC_VARIABLE";
+        final Field testField = Field.getField(TestClassModifiers.class, testFieldName);
+        assertEquals(testFieldName, testField.getName());
+        assertEquals(int.class, testField.getGenericType());
+        assertEquals(int.class, testField.getType());
+        assertEquals(TestClassModifiers.class, testField.getDeclaringClass());
+        //noinspection
+        assertNotNull(testField.getJdkField()); // NOPMD NOSONAR - just for testing can be removed once this become unnecessary
+        assertNotNull(testField.getAnnotations());
+        assertNotNull(testField.getDeclaredAnnotations());
+        assertNull(testField.getAnnotation(MetaInfo.class));
+    }
+
+    @Test
+    void testModifiers() {
+        final Field testField = Field.getField(TestClassModifiers.class, "PRIVATE_TEST_VARIABLE");
+        assertDoesNotThrow(testField::getModifiers);
+        assertTrue(testField.isPrivate());
+        assertFalse(testField.isProtected());
+        assertFalse(testField.isPublic());
+        assertFalse(testField.isPackagePrivate());
+        assertTrue(testField.isPrimitive());
+        assertTrue(testField.isStatic());
+        assertTrue(testField.isFinal());
+        assertTrue(testField.isTransient());
+        assertFalse(testField.isVolatile());
+        assertFalse(testField.isNative());
+        assertFalse(testField.isStrict());
+        assertFalse(testField.isProtected());
+        assertFalse(testField.isAbstract());
+        assertFalse(testField.isSynchronized());
+
+        assertFalse(Field.getField(TestClassModifiers.class, "PROTECTED_TEST_VARIABLE").isPrivate());
+        assertTrue(Field.getField(TestClassModifiers.class, "PROTECTED_TEST_VARIABLE").isProtected());
+        assertFalse(Field.getField(TestClassModifiers.class, "PROTECTED_TEST_VARIABLE").isPublic());
+        assertFalse(Field.getField(TestClassModifiers.class, "PROTECTED_TEST_VARIABLE").isPackagePrivate());
+        assertTrue(Field.getField(TestClassModifiers.class, "PROTECTED_TEST_VARIABLE").isPrimitive());
+
+        assertFalse(Field.getField(TestClassModifiers.class, "PUBLIC_VARIABLE").isPrivate());
+        assertFalse(Field.getField(TestClassModifiers.class, "PUBLIC_VARIABLE").isProtected());
+        assertTrue(Field.getField(TestClassModifiers.class, "PUBLIC_VARIABLE").isPublic());
+        assertFalse(Field.getField(TestClassModifiers.class, "PUBLIC_VARIABLE").isPackagePrivate());
+        assertTrue(Field.getField(TestClassModifiers.class, "PUBLIC_VARIABLE").isPrimitive());
+
+        assertFalse(Field.getField(TestClassModifiers.class, "PACKAGE_PRIVATE_TEST_VARIABLE").isPrivate());
+        assertFalse(Field.getField(TestClassModifiers.class, "PACKAGE_PRIVATE_TEST_VARIABLE").isProtected());
+        assertFalse(Field.getField(TestClassModifiers.class, "PACKAGE_PRIVATE_TEST_VARIABLE").isPublic());
+        assertTrue(Field.getField(TestClassModifiers.class, "PACKAGE_PRIVATE_TEST_VARIABLE").isPackagePrivate());
+        assertTrue(Field.getField(TestClassModifiers.class, "PACKAGE_PRIVATE_TEST_VARIABLE").isPrimitive());
+
+        assertFalse(Field.getField(TestClassModifiers.class, "NON_STATIC_PUBLIC_TEST_VARIABLE").isStatic());
+        assertTrue(Field.getField(TestClassModifiers.class, "NON_STATIC_PUBLIC_TEST_VARIABLE").isVolatile());
+    }
+
+    @Test
+    void testPrimitiveAccess() {
+        final TestClassPrimitiveAccess testClass = new TestClassPrimitiveAccess();
+        final Class<? extends TestClassPrimitiveAccess> clazz = testClass.getClass();
+
+        Field.getField(clazz, "dummyBoolean").setBoolean(testClass, true);
+        assertTrue(testClass.dummyBoolean);
+        assertTrue(Field.getField(clazz, "dummyBoolean").getBoolean(testClass));
+
+        Field.getField(clazz, "dummyByte").setByte(testClass, (byte) 3);
+        assertEquals(3, testClass.dummyByte);
+        assertEquals(testClass.dummyByte, Field.getField(clazz, "dummyByte").getByte(testClass));
+
+        Field.getField(clazz, "dummyChar").setChar(testClass, (char) 4);
+        assertEquals(4, testClass.dummyChar);
+        assertEquals(testClass.dummyChar, Field.getField(clazz, "dummyChar").getChar(testClass));
+
+        Field.getField(clazz, "dummyShort").setShort(testClass, (short) 12);
+        assertEquals(12, testClass.dummyShort);
+        assertEquals(testClass.dummyShort, Field.getField(clazz, "dummyShort").getShort(testClass));
+
+        Field.getField(clazz, "dummyInt").setInt(testClass, 42);
+        assertEquals(42, testClass.dummyInt);
+        assertEquals(testClass.dummyInt, Field.getField(clazz, "dummyInt").getInt(testClass));
+
+        Field.getField(clazz, "dummyLong").setLong(testClass, 42L);
+        assertEquals(42L, testClass.dummyLong);
+        assertEquals(testClass.dummyLong, Field.getField(clazz, "dummyLong").getLong(testClass));
+
+        Field.getField(clazz, "dummyFloat").setFloat(testClass, 1.0f);
+        assertEquals(1.0f, testClass.dummyFloat);
+        assertEquals(testClass.dummyFloat, Field.getField(clazz, "dummyFloat").getFloat(testClass));
+
+        Field.getField(clazz, "dummyDouble").setDouble(testClass, 2.0);
+        assertEquals(2.0, testClass.dummyDouble);
+        assertEquals(testClass.dummyDouble, Field.getField(clazz, "dummyDouble").getDouble(testClass));
+
+        Field.getField(clazz, "dummyString").set(testClass, "test");
+        assertEquals("test", testClass.dummyString);
+        assertEquals(testClass.dummyString, Field.getField(clazz, "dummyString").get(testClass));
+    }
+
+    @Test
+    void testPrimitiveStaticAccess() {
+        final Class<? extends TestClassPrimitiveStaticAccess> clazz = TestClassPrimitiveStaticAccess.class;
+
+        Field.getField(clazz, "dummyBoolean").setBoolean(null, true);
+        assertTrue(TestClassPrimitiveStaticAccess.dummyBoolean);
+        assertTrue(Field.getField(clazz, "dummyBoolean").getBoolean(null));
+
+        Field.getField(clazz, "dummyByte").setByte(null, (byte) 3);
+        assertEquals(3, TestClassPrimitiveStaticAccess.dummyByte);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyByte, Field.getField(clazz, "dummyByte").getByte(null));
+
+        Field.getField(clazz, "dummyChar").setChar(null, (char) 4);
+        assertEquals(4, TestClassPrimitiveStaticAccess.dummyChar);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyChar, Field.getField(clazz, "dummyChar").getChar(null));
+
+        Field.getField(clazz, "dummyShort").setShort(null, (short) 12);
+        assertEquals(12, TestClassPrimitiveStaticAccess.dummyShort);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyShort, Field.getField(clazz, "dummyShort").getShort(null));
+
+        Field.getField(clazz, "dummyInt").setInt(null, 42);
+        assertEquals(42, TestClassPrimitiveStaticAccess.dummyInt);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyInt, Field.getField(clazz, "dummyInt").getInt(null));
+
+        Field.getField(clazz, "dummyLong").setLong(null, 42L);
+        assertEquals(42L, TestClassPrimitiveStaticAccess.dummyLong);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyLong, Field.getField(clazz, "dummyLong").getLong(null));
+
+        Field.getField(clazz, "dummyFloat").setFloat(null, 1.0f);
+        assertEquals(1.0f, TestClassPrimitiveStaticAccess.dummyFloat);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyFloat, Field.getField(clazz, "dummyFloat").getFloat(null));
+
+        Field.getField(clazz, "dummyDouble").setDouble(null, 2.0);
+        assertEquals(2.0, TestClassPrimitiveStaticAccess.dummyDouble);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyDouble, Field.getField(clazz, "dummyDouble").getDouble(null));
+
+        Field.getField(clazz, "dummyString").set(null, "test");
+        assertEquals("test", TestClassPrimitiveStaticAccess.dummyString);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyString, Field.getField(clazz, "dummyString").get(null));
+    }
+
+    @Test
+    void testGenericStringSetterGetter() {
+        final Class<? extends TestClassPrimitiveStaticAccess> clazz = TestClassPrimitiveStaticAccess.class;
+
+        Field.getField(clazz, "dummyInt").set(null, "42");
+        assertEquals(42, TestClassPrimitiveStaticAccess.dummyInt);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyInt, Field.getField(clazz, "dummyInt").get(null));
+
+        Field.getField(clazz, "dummyBoolean").set(null, "true");
+        assertTrue(TestClassPrimitiveStaticAccess.dummyBoolean);
+        assertTrue(Field.getField(clazz, "dummyBoolean").getBoolean(null));
+        assertTrue((boolean) Field.getField(clazz, "dummyBoolean").get(null));
+
+        Field.getField(clazz, "dummyByte").set(null, "3");
+        assertEquals(3, TestClassPrimitiveStaticAccess.dummyByte);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyByte, Field.getField(clazz, "dummyByte").get(null));
+
+        Field.getField(clazz, "dummyChar").set(null, "4");
+        assertEquals('4', TestClassPrimitiveStaticAccess.dummyChar);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyChar, Field.getField(clazz, "dummyChar").get(null));
+
+        Field.getField(clazz, "dummyShort").set(null, "12");
+        assertEquals(12, TestClassPrimitiveStaticAccess.dummyShort);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyShort, Field.getField(clazz, "dummyShort").get(null));
+
+        Field.getField(clazz, "dummyInt").set(null, "42");
+        assertEquals(42, TestClassPrimitiveStaticAccess.dummyInt);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyInt, Field.getField(clazz, "dummyInt").get(null));
+
+        Field.getField(clazz, "dummyLong").set(null, "42");
+        assertEquals(42L, TestClassPrimitiveStaticAccess.dummyLong);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyLong, Field.getField(clazz, "dummyLong").get(null));
+
+        Field.getField(clazz, "dummyFloat").set(null, "1.0");
+        assertEquals(1.0f, TestClassPrimitiveStaticAccess.dummyFloat);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyFloat, Field.getField(clazz, "dummyFloat").get(null));
+
+        Field.getField(clazz, "dummyDouble").set(null, "2.0");
+        assertEquals(2.0, TestClassPrimitiveStaticAccess.dummyDouble);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyDouble, Field.getField(clazz, "dummyDouble").get(null));
+
+        Field.getField(clazz, "dummyString").set(null, "test");
+        assertEquals("test", TestClassPrimitiveStaticAccess.dummyString);
+        assertEquals(TestClassPrimitiveStaticAccess.dummyString, Field.getField(clazz, "dummyString").get(null));
+
+        assertThrows(NumberFormatException.class, () -> Field.getField(clazz, "dummyLong").set(null, "42L"));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "unknownObject").set(null, "??"));
+    }
+
+    @Test
+    @SuppressWarnings({ "StringOperationCanBeSimplified" })
+    void testStringReset() {
+        final String testString1 = "Hello World! - immutable".intern(); //N.B. String content should be unique
+
+        assertEquals("Hello World! - immutable", testString1);
+        Field.resetString(testString1, "Something else.");
+        assertEquals("Something else.", testString1);
+    }
+
+    @Test
+    void testImpossiblePrimitiveAccess() {
+        final Class<? extends TestClassStaticPrimitiveImpossibleWriteAccess> clazz = TestClassStaticPrimitiveImpossibleWriteAccess.class;
+
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyBoolean").setBoolean(null, true));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyByte").setByte(null, (byte) 3));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyChar").setChar(null, (char) 4));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyShort").setShort(null, (short) 12));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyInt").setInt(null, 42));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyLong").setLong(null, 42L));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyFloat").setFloat(null, 1.0f));
+        assertThrows(IllegalArgumentException.class, () -> Field.getField(clazz, "dummyDouble").setDouble(null, 2.0));
+    }
+
+    @Test
+    void testBoxedAccess() {
+        final TestClassBoxedAccess testClass = new TestClassBoxedAccess();
+        final Class<? extends TestClassBoxedAccess> clazz = testClass.getClass();
+
+        Field.getField(clazz, "dummyBoolean").setBoolean(testClass, true);
+        assertTrue(testClass.dummyBoolean);
+        assertTrue(Field.getField(clazz, "dummyBoolean").getBoolean(testClass));
+
+        Field.getField(clazz, "dummyByte").setByte(testClass, (byte) 3);
+        assertEquals((byte) 3, testClass.dummyByte);
+        assertEquals(testClass.dummyByte, Field.getField(clazz, "dummyByte").getByte(testClass));
+
+        Field.getField(clazz, "dummyChar").setChar(testClass, (char) 4);
+        assertEquals((char) 4, testClass.dummyChar);
+        assertEquals(testClass.dummyChar, Field.getField(clazz, "dummyChar").getChar(testClass));
+
+        Field.getField(clazz, "dummyShort").setShort(testClass, (short) 12);
+        assertEquals((short) 12, testClass.dummyShort);
+        assertEquals(testClass.dummyShort, Field.getField(clazz, "dummyShort").getShort(testClass));
+
+        Field.getField(clazz, "dummyInt").setInt(testClass, 42);
+        assertEquals(42, testClass.dummyInt);
+        assertEquals(testClass.dummyInt, Field.getField(clazz, "dummyInt").getInt(testClass));
+
+        Field.getField(clazz, "dummyLong").setLong(testClass, 42L);
+        assertEquals(42L, testClass.dummyLong);
+        assertEquals(testClass.dummyLong, Field.getField(clazz, "dummyLong").getLong(testClass));
+
+        Field.getField(clazz, "dummyFloat").setFloat(testClass, 1.0f);
+        assertEquals(1.0f, testClass.dummyFloat);
+        assertEquals(testClass.dummyFloat, Field.getField(clazz, "dummyFloat").getFloat(testClass));
+
+        Field.getField(clazz, "dummyDouble").setDouble(testClass, 2.0);
+        assertEquals(2.0, testClass.dummyDouble);
+        assertEquals(testClass.dummyDouble, Field.getField(clazz, "dummyDouble").getDouble(testClass));
+
+        Field.getField(clazz, "dummyString").set(testClass, "test");
+        assertEquals("test", testClass.dummyString);
+        assertEquals(testClass.dummyString, Field.getField(clazz, "dummyString").get(testClass));
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void TestClassStaticBoxedAccess() {
+        final Class<?> clazz = TestClassStaticBoxedAccess.class;
+
+        assertFalse(TestClassStaticBoxedAccess.dummyBoolean);
+        Field.getField(clazz, "dummyBoolean").setBoolean(null, true);
+        assertTrue(TestClassStaticBoxedAccess.dummyBoolean); // NOPMD NOSONAR the magic of reflection makes this possible
+        assertTrue(Field.getField(clazz, "dummyBoolean").getBoolean(null));
+
+        Field.getField(clazz, "dummyByte").setByte(null, (byte) 3);
+        assertEquals(3, (int) TestClassStaticBoxedAccess.dummyByte);
+        assertEquals(TestClassStaticBoxedAccess.dummyByte, Field.getField(clazz, "dummyByte").getByte(null));
+
+        Field.getField(clazz, "dummyChar").setChar(null, (char) 4);
+        assertEquals(4, (int) TestClassStaticBoxedAccess.dummyChar);
+        assertEquals(TestClassStaticBoxedAccess.dummyChar, Field.getField(clazz, "dummyChar").getChar(null));
+
+        Field.getField(clazz, "dummyShort").setShort(null, (short) 12);
+        assertEquals(12, (int) TestClassStaticBoxedAccess.dummyShort);
+        assertEquals(TestClassStaticBoxedAccess.dummyShort, Field.getField(clazz, "dummyShort").getShort(null));
+
+        Field.getField(clazz, "dummyInt").setInt(null, 42);
+        assertEquals(42, TestClassStaticBoxedAccess.dummyInt);
+        assertEquals(TestClassStaticBoxedAccess.dummyInt, Field.getField(clazz, "dummyInt").getInt(null));
+
+        Field.getField(clazz, "dummyLong").setLong(null, 42L);
+        assertEquals(42L, TestClassStaticBoxedAccess.dummyLong);
+        assertEquals(TestClassStaticBoxedAccess.dummyLong, Field.getField(clazz, "dummyLong").getLong(null));
+
+        Field.getField(clazz, "dummyFloat").setFloat(null, 1.0f);
+        assertEquals(1.0f, TestClassStaticBoxedAccess.dummyFloat);
+        assertEquals(TestClassStaticBoxedAccess.dummyFloat, Field.getField(clazz, "dummyFloat").getFloat(null));
+
+        Field.getField(clazz, "dummyDouble").setDouble(null, 2.0);
+        assertEquals(2.0, TestClassStaticBoxedAccess.dummyDouble);
+        assertEquals(TestClassStaticBoxedAccess.dummyDouble, Field.getField(clazz, "dummyDouble").getDouble(null));
+
+        Field.getField(clazz, "dummyString").set(null, "test");
+        // this doesn't seem to be working -- possible early JIT optimisation for inlining 'static final' Strings
+        // assertEquals("test", TestClassStaticBoxedAccess.dummyString);
+        assertEquals("test", Field.getField(clazz, "dummyString").get(null));
+    }
+
+    /**
+     * small test class - do not remove test fields these are all access via reflection
+     */
+    private static class TestClassModifiers {
+        public static final transient int PUBLIC_VARIABLE = 3;
+        protected static final transient int PROTECTED_TEST_VARIABLE = 2;
+        static final transient int PACKAGE_PRIVATE_TEST_VARIABLE = 4;
+        private static final transient int PRIVATE_TEST_VARIABLE = 1;
+        public transient volatile double NON_STATIC_PUBLIC_TEST_VARIABLE = 5.0;
+    }
+
+    private static class TestClassPrimitiveAccess {
+        protected boolean dummyBoolean;
+        protected byte dummyByte;
+        protected char dummyChar;
+        protected short dummyShort;
+        protected int dummyInt;
+        protected long dummyLong;
+        protected float dummyFloat;
+        protected double dummyDouble;
+        protected String dummyString = "Test";
+    }
+
+    /**
+     * small test class - do not remove test fields these are all access via reflection
+     */
+    private static class TestClassPrimitiveStaticAccess {
+        protected static boolean dummyBoolean;
+        protected static byte dummyByte;
+        protected static char dummyChar;
+        protected static short dummyShort;
+        protected static int dummyInt;
+        protected static long dummyLong;
+        protected static float dummyFloat;
+        protected static double dummyDouble;
+        protected static String dummyString = "Test";
+        protected static Object unknownObject;
+    }
+
+    /**
+     * small test class - do not remove test fields these are all access via reflection
+     */
+    private static class TestClassStaticPrimitiveImpossibleWriteAccess {
+        public static final boolean dummyBoolean = false;
+        public static final byte dummyByte = (byte) 0x04;
+        public static final char dummyChar = (char) 0x02;
+        public static final short dummyShort = (short) 0x05;
+        public static final int dummyInt = 0x05;
+        public static final long dummyLong = 0x07;
+        public static final float dummyFloat = 41.0f;
+        public static final double dummyDouble = 42.0;
+    }
+
+    private static class TestClassBoxedAccess {
+        protected Boolean dummyBoolean;
+        protected Byte dummyByte;
+        protected Character dummyChar;
+        protected Short dummyShort;
+        protected Integer dummyInt;
+        protected Long dummyLong;
+        protected Float dummyFloat;
+        protected Double dummyDouble;
+        protected String dummyString = "Test";
+    }
+
+    public static class TestClassStaticBoxedAccess {
+        public static final Boolean dummyBoolean = false;
+        public static final Byte dummyByte = (byte) 0;
+        public static final Character dummyChar = (char) 0;
+        public static final Short dummyShort = (short) 0;
+        public static final Integer dummyInt = 0;
+        public static final Long dummyLong = 0L;
+        public static final Float dummyFloat = .0f;
+        public static final Double dummyDouble = .0;
+        public static final String dummyString = "";
+    }
+}

--- a/server-rest/src/main/java/io/opencmw/server/rest/MajordomoRestPlugin.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/MajordomoRestPlugin.java
@@ -6,6 +6,7 @@ import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.post;
 import static io.javalin.plugin.openapi.dsl.DocumentedContentKt.anyOf;
 import static io.javalin.plugin.openapi.dsl.DocumentedContentKt.documentedContent;
+import static io.opencmw.OpenCmwConstants.HEARTBEAT_LIVENESS;
 import static io.opencmw.OpenCmwConstants.setDefaultSocketParameters;
 import static io.opencmw.OpenCmwProtocol.Command.GET_REQUEST;
 import static io.opencmw.OpenCmwProtocol.Command.READY;
@@ -309,7 +310,7 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
                         final MdpMessage brokerMsg = receive(subSocket, false);
                         if (brokerMsg != null) {
                             dataReceived = true;
-                            liveness = heartBeatLiveness;
+                            liveness = HEARTBEAT_LIVENESS;
 
                             // handle subscription message
                             if (brokerMsg.data != null && brokerMsg.getServiceName().startsWith(INTERNAL_SERVICE_NAMES)) {

--- a/server-rest/src/main/java/io/opencmw/server/rest/RestCommonThreadPool.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/RestCommonThreadPool.java
@@ -48,7 +48,7 @@ public final class RestCommonThreadPool implements ThreadFactory {
     private static int getDefaultScheduledThreadCount() {
         int nthreads = 32;
         try {
-            nthreads = Integer.parseInt(System.getProperty("restScheduledThreadCount", "32"));
+            nthreads = RestServerSettings.SCHEDULED_THREAD_COUNT;
         } catch (final NumberFormatException e) {
             // malformed number
         }
@@ -59,7 +59,7 @@ public final class RestCommonThreadPool implements ThreadFactory {
     private static int getDefaultThreadCount() {
         int nthreads = 32;
         try {
-            nthreads = Integer.parseInt(System.getProperty("restThreadCount", "64"));
+            nthreads = RestServerSettings.THREAD_COUNT;
         } catch (final NumberFormatException e) {
             // malformed number
         }

--- a/server-rest/src/main/java/io/opencmw/server/rest/RestServerSettings.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/RestServerSettings.java
@@ -1,0 +1,26 @@
+package io.opencmw.server.rest;
+
+import io.opencmw.serialiser.annotations.MetaInfo;
+import io.opencmw.utils.Settings;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(Settings.class)
+public class RestServerSettings implements Settings {
+    @MetaInfo(description = "restKeyStorePassword")
+    public static final String REST_KEY_STORE_PASSWORD = "";
+    @MetaInfo(description = "restKeyStore")
+    public static final String REST_KEY_STORE = "";
+    @MetaInfo(description = "rest server hostname")
+    public static final String DEFAULT_HOST_NAME = "0";
+    @MetaInfo(description = "rest server plain http port")
+    public static final Integer DEFAULT_PORT = 8080;
+    @MetaInfo(description = "rest server ssl port")
+    public static final Integer DEFAULT_PORT2 = 8443;
+    @MetaInfo(description = "password store file location, defaults to (insecure) internal store")
+    public static final String USER_PASSWORD_STORE = "";
+    @MetaInfo(description = "scheduled thread count")
+    public static final Integer SCHEDULED_THREAD_COUNT = 32;
+    @MetaInfo(description = "thread count")
+    public static final Integer THREAD_COUNT = 64;
+}

--- a/server-rest/src/main/java/io/opencmw/server/rest/user/RestUserHandlerImpl.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/user/RestUserHandlerImpl.java
@@ -22,10 +22,10 @@ import org.slf4j.LoggerFactory;
 import io.opencmw.rbac.BasicRbacRole;
 import io.opencmw.rbac.RbacRole;
 import io.opencmw.server.rest.RestServer;
+import io.opencmw.server.rest.RestServerSettings;
 
 public class RestUserHandlerImpl implements RestUserHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RestUserHandlerImpl.class);
-    private static final String REST_USER_PASSWORD_STORE = "restUserPasswordStore";
     /**
      * the password file location is statically allocated so that it cannot (for
      * security reasons) be overwritting during run time
@@ -95,8 +95,8 @@ public class RestUserHandlerImpl implements RestUserHandler {
             LOGGER.atDebug().log("readPasswordFile called");
         }
         synchronized (usersLock) {
-            try (BufferedReader br = REST_USER_PASSWORD_FILE == null ? new BufferedReader(new InputStreamReader(RestServer.class.getResourceAsStream("/DefaultRestUserPasswords.pwd"), StandardCharsets.UTF_8)) //
-                                                                     : Files.newBufferedReader(Paths.get(new File(REST_USER_PASSWORD_FILE).getPath()), StandardCharsets.UTF_8)) {
+            try (BufferedReader br = (REST_USER_PASSWORD_FILE == null ? new BufferedReader(new InputStreamReader(RestServer.class.getResourceAsStream("/DefaultRestUserPasswords.pwd"), StandardCharsets.UTF_8)) //
+                                                                      : Files.newBufferedReader(Paths.get(new File(REST_USER_PASSWORD_FILE).getPath()), StandardCharsets.UTF_8))) {
                 final List<RestUser> newUserList = new ArrayList<>(10);
                 String userLine;
                 int lineCount = 0;
@@ -194,10 +194,10 @@ public class RestUserHandlerImpl implements RestUserHandler {
     }
 
     private static String getUserPasswordStore() {
-        final String passWordStore = System.getProperty(REST_USER_PASSWORD_STORE);
-        if (passWordStore == null) {
+        if (RestServerSettings.USER_PASSWORD_STORE.isBlank()) {
             LOGGER.atWarn().log("using internal UserPasswordStore -- PLEASE CHANGE FOR PRODUCTION -- THIS IS UNSAFE PRACTICE");
+            return null;
         }
-        return passWordStore;
+        return RestServerSettings.USER_PASSWORD_STORE;
     }
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -4,7 +4,7 @@ open module io.opencmw.server {
     requires io.opencmw;
     requires jeromq;
     requires java.management;
-    requires it.unimi.dsi.fastutil;
+    requires it.unimi.dsi.fastutil.core;
     requires org.apache.commons.lang3;
     requires velocity.engine.core;
     requires org.jetbrains.annotations;

--- a/server/src/test/java/io/opencmw/server/BasicMdpWorkerTest.java
+++ b/server/src/test/java/io/opencmw/server/BasicMdpWorkerTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import static io.opencmw.OpenCmwConstants.HEARTBEAT_INTERVAL;
 import static io.opencmw.OpenCmwProtocol.Command.W_NOTIFY;
 import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
 import static io.opencmw.OpenCmwProtocol.EMPTY_URI;
@@ -100,7 +101,7 @@ class BasicMdpWorkerTest {
         assertTrue(worker.notifyRaw(msg)); // is unfiltered: no subscription -> true
 
         // wait for five heartbeats -> checks poller, heartbeat and reconnect features (to some extend)
-        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5L * worker.heartBeatInterval));
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5L * HEARTBEAT_INTERVAL));
 
         new Thread(() -> {
             run.set(true);

--- a/server/src/test/java/io/opencmw/server/MajordomoBrokerTests.java
+++ b/server/src/test/java/io/opencmw/server/MajordomoBrokerTests.java
@@ -38,6 +38,7 @@ import io.opencmw.domain.BinaryData;
 import io.opencmw.domain.NoData;
 import io.opencmw.rbac.BasicRbacRole;
 import io.opencmw.rbac.RbacToken;
+import io.opencmw.serialiser.spi.Field;
 
 @Timeout(60)
 class MajordomoBrokerTests {
@@ -261,8 +262,8 @@ class MajordomoBrokerTests {
 
     @Test
     void testDNS() throws IOException {
-        System.setProperty(OpenCmwConstants.HEARTBEAT, "100"); // to reduce waiting time for changes
-        System.setProperty(DNS_TIMEOUT, "1"); // to reduce waiting time for changes
+        Field.getField(OpenCmwConstants.class, "HEARTBEAT_INTERVAL").setInt(null, 100); // to reduce waiting time for changes
+        Field.getField(OpenCmwConstants.class, "DNS_TIMEOUT").setInt(null, 2); // to reduce waiting time for changes
         final MajordomoBroker primaryBroker = new MajordomoBroker(DEFAULT_BROKER_NAME + "1", null);
         final URI brokerAddress = primaryBroker.bind(URI.create("mdp://*:" + Utils.findOpenPort()));
         primaryBroker.start();
@@ -476,7 +477,7 @@ class MajordomoBrokerTests {
 
     @Test
     void testMisc() {
-        System.setProperty(OpenCmwConstants.HEARTBEAT, "100"); // to reduce waiting time for changes
+        Field.getField(OpenCmwConstants.class, "HEARTBEAT_INTERVAL").setInt(null, 100); // to reduce waiting time for changes
         final MajordomoBroker broker = new MajordomoBroker(DEFAULT_BROKER_NAME, null, BasicRbacRole.values());
         assertDoesNotThrow(() -> broker.new Client(null, "testClient", "testClient".getBytes(UTF_8)));
         final MajordomoBroker.Client testClient = broker.new Client(null, "testClient", "testClient".getBytes(UTF_8));


### PR DESCRIPTION
Three little commits (the suggestions is not to squash them):
* bump dependencies for fastutil, jmh and oshi-core 
   N.B the last being used in unit-tests only

* refactored ClassFieldDescription and reflection Field handling

* added command-line, property, and config-file compatible interface

The latter generically allows the default parameters/settings (i.e. stored as fields in domain-object classes) to be updated based other parameters based on a config-file (lowest priority), the VM environment variables, or the program's command-line arguments. The field parameter may be 'final' and/or 'static' with the exception of 'static final' primitives since these (especially Strings) are likely to be inlined by the JVM. However, unique Strings maybe changed also during run-time (e.g. blanking String that may contain plain-text passwords before behing hashed).

Comments, proposals and improvements are welcome.


