### PR TITLE
Fix deserialisation of nested inner static classes

### DIFF
--- a/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
@@ -196,13 +196,12 @@ public class ClassFieldDescription implements FieldDescription {
     public Object allocateMemberClassField(final Object fieldParent) {
         try {
             // need to allocate new class object
-            Class<?> fieldParentClass = ClassUtils.getRawType(getParent(this, 1).getType());
             final Object newFieldObj;
-            if (fieldParentClass.getDeclaringClass() == null) {
-                final Constructor<?> constr = fieldParentClass.getDeclaredConstructor();
+            if (this.classType.getDeclaringClass() == null || Modifier.isStatic(this.classType.getModifiers())) {
+                final Constructor<?> constr = this.classType.getDeclaredConstructor();
                 newFieldObj = constr.newInstance();
             } else {
-                final Constructor<?> constr = fieldParentClass.getDeclaredConstructor(fieldParent.getClass());
+                final Constructor<?> constr = this.classType.getDeclaredConstructor(fieldParent.getClass());
                 newFieldObj = constr.newInstance(fieldParent);
             }
             this.getField().set(fieldParent, newFieldObj);

--- a/serialiser/src/test/java/io/opencmw/serialiser/IoClassSerialiserTests.java
+++ b/serialiser/src/test/java/io/opencmw/serialiser/IoClassSerialiserTests.java
@@ -441,13 +441,12 @@ class IoClassSerialiserTests {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (!(o instanceof NestedClass)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof NestedClass))
+                return false;
             final NestedClass that = (NestedClass) o;
-            return i == that.i &&
-                    Objects.equals(class1, that.class1) &&
-                    Objects.equals(class2, that.class2) &&
-                    Objects.equals(class3, that.class3);
+            return i == that.i && Objects.equals(class1, that.class1) && Objects.equals(class2, that.class2) && Objects.equals(class3, that.class3);
         }
 
         @Override
@@ -457,12 +456,8 @@ class IoClassSerialiserTests {
 
         @Override
         public String toString() {
-            return "NestedClass{" +
-                    "class1=" + class1 +
-                    ", class2=" + class2 +
-                    ", class3=" + class3 +
-                    ", i=" + i +
-                    '}';
+            return "NestedClass{"
+          + "class1=" + class1 + ", class2=" + class2 + ", class3=" + class3 + ", i=" + i + '}';
         }
 
         public class NonStaticInnerClass {
@@ -477,13 +472,16 @@ class IoClassSerialiserTests {
 
             @Override
             public String toString() {
-                return "NonStaticInnerClass{" + "j=" + j + ", parent:i=" + i + '}'; // include parent so class cannot become static
+                return "NonStaticInnerClass{"
+              + "j=" + j + ", parent:i=" + i + '}'; // include parent so class cannot become static
             }
 
             @Override
             public boolean equals(final Object o) {
-                if (this == o) return true;
-                if (!(o instanceof NonStaticInnerClass)) return false;
+                if (this == o)
+                    return true;
+                if (!(o instanceof NonStaticInnerClass))
+                    return false;
                 final NonStaticInnerClass that = (NonStaticInnerClass) o;
                 return j == that.j;
             }


### PR DESCRIPTION
For fields with static inner classes as their type, the deserialiser
always assumes non-static inner classes and cannot find the constructor.
If one attempts to deserialise such an object the deserialiser will
throw `NoSuchMethodException` (which is caught and printed to the log
before continuing) when trying to allocate the field using the constructor
with the parent class as its default argument.

This PR adds a testcase for a nested class with static and
non-static nested class fields.
The fix consists of checking for the `static` modifier after determining
an inner class and treating static inner classes the same as normal
classes.

For the non-static member classes I'm not sure if this is the right way
to do it, but I didn't want to change the code too much as I was not 100%
clear about the intent of the code.
The assumption that the parent of the nested class has to be identical
with the class the field doesn't seem to align with the typical applications
for inner classes. :thinking:

I'm also not sure about the previous use of getRawType which I removed,
something like this is necessary for generic types?