### PR TITLE
bumped versions and fixed command-line interface

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>5.7.0</version>
+            <version>5.7.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/src/main/java/module-info.java
+++ b/client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module io.opencmw.client {
-    requires disruptor;
+    requires com.lmax.disruptor;
     requires io.opencmw;
     requires io.opencmw.serialiser;
     requires it.unimi.dsi.fastutil.core;

--- a/concepts/src/main/java/module-info.java
+++ b/concepts/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module io.opencmw.concepts {
     requires org.slf4j;
-    requires disruptor;
+    requires com.lmax.disruptor;
     requires jeromq;
     requires java.management;
     requires io.opencmw;

--- a/core/src/main/java/io/opencmw/OpenCmwConstants.java
+++ b/core/src/main/java/io/opencmw/OpenCmwConstants.java
@@ -84,10 +84,6 @@ public final class OpenCmwConstants implements Settings {
     @MetaInfo(unit = "n2", description = "after <n2> failed attempts the retry-'heartBeat interval is increased 100-fold")
     public static final Integer RECONNECT_THRESHOLD2 = 6;
 
-    static { // init properties with default values given in the description text above
-        init();
-    }
-
     public static void init() {
         SystemProperties.addCommandOptions(OpenCmwConstants.class);
     }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 open module io.opencmw {
     uses io.opencmw.utils.Settings;
     requires com.google.auto.service;
-    requires disruptor;
+    requires com.lmax.disruptor;
     requires org.slf4j;
     requires jeromq;
     requires io.opencmw.serialiser;

--- a/core/src/test/java/io/opencmw/OpenCmwConstantsTest.java
+++ b/core/src/test/java/io/opencmw/OpenCmwConstantsTest.java
@@ -20,7 +20,12 @@ import io.opencmw.utils.SystemProperties;
 class OpenCmwConstantsTest {
     @BeforeAll
     static void init() {
-        OpenCmwConstants.init(); // needed to execute once -- other class member function invocation work as well
+        try {
+            OpenCmwConstants.init(); // needed to execute once -- other class member function invocation work as well
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        }
     }
 
     @Test

--- a/core/src/test/java/io/opencmw/utils/SystemPropertiesExample.java
+++ b/core/src/test/java/io/opencmw/utils/SystemPropertiesExample.java
@@ -1,0 +1,26 @@
+package io.opencmw.utils;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Small usage example for SystemProperties command line interface
+ * call with e.g. '--OpenCmwConstants.DNS_TIMEOUT=2' or '-h' or '--help' for help
+ */
+public class SystemPropertiesExample {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemPropertiesExample.class);
+
+    public static void main(String[] argv) {
+        if (argv.length == 0) {
+            SystemProperties.parseOptions(new String[] { "-h" });
+        }
+        final Map<String, Object> cmdLineValues = SystemProperties.parseOptions(argv);
+        if (!cmdLineValues.isEmpty()) {
+            LOGGER.atInfo().addArgument(cmdLineValues).log("cmd line values set: {}");
+        }
+
+        LOGGER.atInfo().log("main finished");
+    }
+}

--- a/core/src/test/java/io/opencmw/utils/SystemPropertiesTest.java
+++ b/core/src/test/java/io/opencmw/utils/SystemPropertiesTest.java
@@ -4,55 +4,76 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import static io.opencmw.utils.SystemProperties.parseOptions;
 
+import java.net.URL;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 
-import org.docopt.DocoptExitException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.opencmw.serialiser.annotations.MetaInfo;
 import io.opencmw.serialiser.spi.Field;
 
+import com.google.auto.service.AutoService;
+
 class SystemPropertiesTest {
+    private static Properties originalStore;
+
+    @BeforeAll
+    static void register() {
+        SystemProperties.addCommandOptions(TestOptionClass.class);
+        originalStore = System.getProperties();
+    }
+
     @BeforeEach
     void init() {
         // re-initialise properties before each test
+        System.getProperties().clear();
+        System.getProperties().putAll(originalStore);
         SystemProperties.put("testString", "test");
         SystemProperties.put("testInt", "42");
         SystemProperties.put("testLong", "43");
         SystemProperties.put("testDouble", "44.0");
     }
 
-    @SuppressWarnings("InstantiationOfUtilityClass")
     @Test
     void testCommandLineOptions() {
         Field.getField(SystemProperties.class, "WITH_EXIT").setBoolean(null, false); // needed only for testing purposes
 
         final Map<String, Object> ret = parseOptions(new String[0]);
         assertNotNull(ret);
-        assertFalse(ret.isEmpty());
+        assertTrue(ret.isEmpty());
+
+        try {
+            // malformed argument
+            parseOptions(new String[] { "--a==0" });
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("could not parse command line options: [--a==0]", e.getMessage());
+        }
 
         try {
             parseOptions(new String[] { "--version" });
             fail();
-        } catch (DocoptExitException e) {
+        } catch (IllegalArgumentException e) {
             assertEquals(SystemProperties.version, e.getMessage());
         }
 
-        assertThrows(DocoptExitException.class, () -> parseOptions(new String[] { "-h" }));
-        assertThrows(DocoptExitException.class, () -> parseOptions(new String[] { "-help" }));
+        assertThrows(IllegalArgumentException.class, () -> parseOptions(new String[] { "-h" }));
+        assertThrows(IllegalArgumentException.class, () -> parseOptions(new String[] { "-help" }));
 
         final String testCommand = "  <program> myCommand [options] command documentation\n";
         SystemProperties.addCommandArgument(testCommand);
 
-        SystemProperties.addCommandOptions(new TestOptionClass());
         // uncomment for testing:
         // System.err.println(SystemProperties.getCommandLineDoc())
         try {
-            parseOptions(new String[] { "-help" });
+            parseOptions(new String[] { "-h" });
             fail();
-        } catch (DocoptExitException e) {
-            assertTrue(e.getMessage().contains(testCommand.split("<program>")[1]));
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains(testCommand));
             assertTrue(e.getMessage().contains(TestOptionClass.TEST_OPTION_DOC));
         }
 
@@ -67,9 +88,9 @@ class SystemPropertiesTest {
         SystemProperties.COMMAND_OPTION_CLASSES.clear();
         // uncomment for testing:
         try {
-            parseOptions(new String[] { "-help" });
+            parseOptions(new String[] { "--help" });
             fail();
-        } catch (DocoptExitException e) {
+        } catch (IllegalArgumentException e) {
             assertFalse(e.getMessage().contains(testCommand));
             assertFalse(e.getMessage().contains(TestOptionClass.TEST_OPTION_DOC));
         }
@@ -77,6 +98,29 @@ class SystemPropertiesTest {
         Field.getField(SystemProperties.class, "WITH_EXIT").setBoolean(null, true); // needed only for testing purposes
     }
 
+    @Test
+    void testHierarchy() {
+        assertTrue(parseOptions(new String[] {}).isEmpty(), "empty map");
+        final String option = "SystemPropertiesTest$TestOptionClass.TEST_OPTION";
+        final URL configFileUrl = SystemProperties.class.getResource("SimplePropertiesTest.properties");
+        final String configFile = Objects.requireNonNull(configFileUrl, "could not find test config file").getPath();
+        final String configFileError = configFile + "Error";
+
+        // setting via config file
+        assertEquals(45, Integer.parseInt(parseOptions(new String[] { "--config=" + configFile }).get(option).toString()));
+        assertThrows(IllegalArgumentException.class, () -> parseOptions(new String[] { "--config=" + configFileError }));
+
+        // setting via vm property
+        SystemProperties.put(option, "43");
+        assertEquals(43, Integer.parseInt(parseOptions(new String[] {}).get(option).toString()));
+        assertEquals(43, Integer.parseInt(parseOptions(new String[] { "--config=" + configFile }).get(option).toString()));
+
+        // setting via command line
+        assertEquals(42, Integer.parseInt(parseOptions(new String[] { "--" + option + "=42" }).get(option).toString()));
+        assertEquals(42, Integer.parseInt(parseOptions(new String[] { "--config=" + configFile }).get(option).toString()));
+    }
+
+    @AutoService(Settings.class)
     private static class TestOptionClass {
         public static final String TEST_OPTION_DOC = "TestOptionClass.TEST_OPTION=<int>";
         @MetaInfo(unit = "int", description = "test option documentation")

--- a/core/src/test/resources/io/opencmw/utils/SimplePropertiesTest.properties
+++ b/core/src/test/resources/io/opencmw/utils/SimplePropertiesTest.properties
@@ -1,0 +1,1 @@
+SystemPropertiesTest$TestOptionClass.TEST_OPTION=45

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
         <version.auto-service>1.0-rc7</version.auto-service>
         <version.jetbrains.annotations>20.1.0</version.jetbrains.annotations>
         <version.jeromq>0.5.2</version.jeromq>
-        <versions.lmax.disruptor>3.4.2</versions.lmax.disruptor>
-        <version.javalin>3.13.4</version.javalin>
-        <version.jetty>9.4.35.v20201120</version.jetty> <!-- N.B. needs to be synchronised/tested with Javalin version -->
+        <versions.lmax.disruptor>3.4.4</versions.lmax.disruptor>
+        <version.javalin>3.13.7</version.javalin>
+        <version.jetty>9.4.42.v20210604</version.jetty> <!-- N.B. needs to be synchronised/tested with Javalin version -->
         <version.jsoniter>0.9.23</version.jsoniter>
         <version.fastutil>8.5.4</version.fastutil>
         <version.javassist>3.27.0-GA</version.javassist>
@@ -44,7 +44,7 @@
         <version.awaitility>4.0.3</version.awaitility>
         <version.JMemoryBuddy>0.5.0</version.JMemoryBuddy>
         <version.jmh>1.29</version.jmh>
-        <version.micrometer>1.6.5</version.micrometer>
+        <version.micrometer>1.6.6</version.micrometer>
         <version.velocity>2.3</version.velocity>
         <version.chartfx>11.2.5</version.chartfx>
         <version.docopt>0.6.0.20150202</version.docopt>
@@ -202,7 +202,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>
@@ -304,7 +304,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -345,7 +345,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/serialiser/pom.xml
+++ b/serialiser/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.2</version>
+            <version>2.12.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.75</version>
+            <version>1.2.76</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/spi/ClassFieldDescription.java
@@ -628,7 +628,7 @@ public class ClassFieldDescription implements FieldDescription {
             return;
         }
         if (recursionLevel > ClassUtils.getMaxRecursionDepth()) {
-            throw new IllegalStateException("recursion error while scanning object structure: recursionLevel = '"
+            throw new IllegalStateException("recursion error while scanning " + parent.getTypeName() + "::" + classType.getName() + " structure: recursionLevel = '"
                                             + recursionLevel + "' > " + ClassFieldDescription.class.getSimpleName() + ".maxRecursionLevel ='"
                                             + ClassUtils.getMaxRecursionDepth() + "'");
         }

--- a/serialiser/src/main/java/io/opencmw/serialiser/utils/ClassUtils.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/utils/ClassUtils.java
@@ -66,6 +66,7 @@ public final class ClassUtils { //NOPMD nomen est omen
         // boxed arrays
 
         // do not parse following classes
+        DO_NOT_PARSE_MAP.put(Object.class, "private java implementation");
         DO_NOT_PARSE_MAP.put(Class.class, "private java implementation");
         DO_NOT_PARSE_MAP.put(Thread.class, "recursive definitions"); // NOPMD - not an issue/not a use within a J2EE context
         DO_NOT_PARSE_MAP.put(AtomicBoolean.class, DOES_NOT_LIKE_TO_BE_PARSED);

--- a/server-rest/pom.xml
+++ b/server-rest/pom.xml
@@ -74,6 +74,23 @@
             <artifactId>jetty-alpn-conscrypt-server</artifactId>
             <version>${version.jetty}</version>
         </dependency>
+        <!-- bump jetty version due to CVE issue -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${version.jetty}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${version.jetty}</version>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.eclipse.jetty.websocket</groupId>-->
+<!--            <artifactId>websocket-server</artifactId>-->
+<!--            <version>${version.jetty}</version>-->
+<!--        </dependency>-->
+
 
         <!-- HTTP template engine-->
         <dependency>

--- a/server-rest/src/main/java/io/opencmw/server/rest/MajordomoRestPlugin.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/MajordomoRestPlugin.java
@@ -8,10 +8,7 @@ import static io.javalin.plugin.openapi.dsl.DocumentedContentKt.anyOf;
 import static io.javalin.plugin.openapi.dsl.DocumentedContentKt.documentedContent;
 import static io.opencmw.OpenCmwConstants.HEARTBEAT_LIVENESS;
 import static io.opencmw.OpenCmwConstants.setDefaultSocketParameters;
-import static io.opencmw.OpenCmwProtocol.Command.GET_REQUEST;
-import static io.opencmw.OpenCmwProtocol.Command.READY;
-import static io.opencmw.OpenCmwProtocol.Command.SET_REQUEST;
-import static io.opencmw.OpenCmwProtocol.Command.UNKNOWN;
+import static io.opencmw.OpenCmwProtocol.Command.*;
 import static io.opencmw.OpenCmwProtocol.EMPTY_FRAME;
 import static io.opencmw.OpenCmwProtocol.MdpMessage;
 import static io.opencmw.OpenCmwProtocol.MdpMessage.receive;
@@ -49,6 +46,7 @@ import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 
+import io.javalin.Javalin;
 import io.javalin.apibuilder.ApiBuilder;
 import io.javalin.core.security.Role;
 import io.javalin.http.BadRequestResponse;
@@ -98,11 +96,12 @@ import com.jsoniter.spi.JsonException;
  * @author rstein
  */
 @MetaInfo(description = "Majordomo Broker REST/HTTP plugin.<br><br>"
-                        + " This opens two http ports and converts and forwards incoming request to the OpenCMW protocol and provides<br>"
-                        + " some basic admin functionality<br>",
+                      + " This opens two http ports and converts and forwards incoming request to the OpenCMW protocol and provides<br>"
+                      + " some basic admin functionality<br>",
         unit = "MajordomoRestPlugin")
 @SuppressWarnings({ "PMD.ExcessiveImports", "PMD.TooManyStaticImports", "PMD.DoNotUseThreads" }) // makes the code more readable/shorter lines
 public class MajordomoRestPlugin extends BasicMdpWorker {
+    protected static final byte[] REST_SUB_ID = "REST_SUBSCRIPTION".getBytes(UTF_8);
     private static final Logger LOGGER = LoggerFactory.getLogger(MajordomoRestPlugin.class);
     private static final byte[] RBAC = {}; // TODO: implement RBAC between Majordomo and Worker
     private static final int LAST_NOTIFY_MAX_HISTORY = 20; // remember last 10 notifications
@@ -115,16 +114,8 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
     private static final String TAG_NOTIFY_ID = "notifyID";
     private static final AtomicLong REQUEST_COUNTER = new AtomicLong();
     private static final AtomicLong NOTIFY_COUNTER = new AtomicLong();
-    protected final ZMQ.Socket subSocket;
-    protected final Map<String, AtomicInteger> subscriptionCount = new ConcurrentHashMap<>();
-    protected final Map<Long, MdpMessage> subscriptionCache; // <notify_counter, last message>
-    protected static final byte[] REST_SUB_ID = "REST_SUBSCRIPTION".getBytes(UTF_8);
-    protected final ConcurrentMap<String, OpenApiDocumentation> registeredEndpoints = new ConcurrentHashMap<>();
-    private final BlockingArrayQueue<MdpMessage> requestQueue = new BlockingArrayQueue<>();
-    private final ConcurrentMap<String, CustomFuture<MdpMessage>> requestReplies = new ConcurrentHashMap<>();
-    private final BiConsumer<SseClient, CombinedHandler.SseState> newSseClientHandler;
-    private final AtomicReference<String> rootService = new AtomicReference<>("/mmi.service");
-    private final Map<String, String> menuMap = new ConcurrentSkipListMap<>(); // NOPMD NOSONAR <menu-tag,property-path>
+    private final transient Javalin restInstance = RestServer.getInstance(); // NOSONAR NOPMD -- transient is necessary
+
     static {
         try {
             Base64Support.enable();
@@ -132,6 +123,16 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
             // do nothing -- ensures that this is initialised only once
         }
     }
+
+    protected final ZMQ.Socket subSocket;
+    protected final Map<String, AtomicInteger> subscriptionCount = new ConcurrentHashMap<>();
+    protected final Map<Long, MdpMessage> subscriptionCache; // <notify_counter, last message>
+    protected final ConcurrentMap<String, OpenApiDocumentation> registeredEndpoints = new ConcurrentHashMap<>();
+    private final BlockingArrayQueue<MdpMessage> requestQueue = new BlockingArrayQueue<>();
+    private final ConcurrentMap<String, CustomFuture<MdpMessage>> requestReplies = new ConcurrentHashMap<>();
+    private final BiConsumer<SseClient, CombinedHandler.SseState> newSseClientHandler;
+    private final AtomicReference<String> rootService = new AtomicReference<>("/mmi.service");
+    private final Map<String, String> menuMap = new ConcurrentSkipListMap<>(); // NOPMD NOSONAR <menu-tag,property-path>
 
     public MajordomoRestPlugin(ZContext ctx, final String serverDescription, String httpAddress, final RbacRole<?>... rbacRoles) {
         super(ctx, MajordomoRestPlugin.class.getSimpleName(), rbacRoles);
@@ -158,7 +159,7 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
         };
 
         // add default root - here: redirect to mmi.service
-        RestServer.getInstance().get("/", restCtx -> restCtx.redirect(rootService.get()), RestServer.getDefaultRole());
+        restInstance.get("/", restCtx -> restCtx.redirect(rootService.get()), RestServer.getDefaultRole());
 
         registerHandler(getDefaultRequestHandler()); // NOPMD - one-time call OK
 
@@ -207,23 +208,16 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
             final MdpMessage msg = reply.get();
             services = msg.data == null ? "" : new String(msg.data, UTF_8);
             Arrays.stream(StringUtils.split(services, ",:;")).forEach(this::registerEndPoint);
-        } catch (final Exception e) { // NOPMD -- erroneous worker replies shall not stop the broker
+        } catch (final Exception e) { // NOSONAR NOPMD -- erroneous worker replies shall not stop the broker
             LOGGER.atError().setCause(e).addArgument(services).log("could not perform initial registering of endpoints {}");
         }
     }
 
-    protected static OpenCmwProtocol.Command getCommand(@NotNull final Context restCtx) {
-        switch (restCtx.method()) {
-        case "GET":
-            return GET_REQUEST;
-        case "POST":
-            return SET_REQUEST;
-        default:
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.atWarn().addArgument(restCtx.req).log("unknown request: {}");
-            }
-            return UNKNOWN;
-        }
+    @Override
+    public void stopWorker() {
+        super.stopWorker();
+        shallRun.set(false);
+        restInstance.stop();
     }
 
     protected RequestHandler getDefaultRequestHandler() {
@@ -354,7 +348,7 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
                     OpenApiDocumentation openApi = getOpenApiDocumentation(handlerClassName);
 
                     final Set<Role> accessRoles = RestServer.getDefaultRole();
-                    RestServer.getInstance().routes(() -> {
+                    restInstance.routes(() -> {
                         ApiBuilder.before(ep, restCtx -> {
                             // for some strange reason this needs to be executed to be able to read 'restCtx.formParamMap()'
                             if ("POST".equals(restCtx.method())) {
@@ -369,12 +363,31 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
                     });
 
                     return openApi;
-                } catch (final Exception e) { // NOPMD -- erroneous worker replies shall not stop the broker
+                } catch (final Exception e) { // NOSONAR NOPMD -- erroneous worker replies shall not stop the broker
                     LOGGER.atError().setCause(e).addArgument(ep).log("could not register endpoint {}");
                 }
                 return null;
             });
         }
+    }
+
+    protected void notifySubscribedClients(final @NotNull MdpMessage msg) {
+        final long notifyID = NOTIFY_COUNTER.getAndIncrement();
+        try {
+            msg.topic = QueryParameterParser.appendQueryParameter(msg.topic, TAG_NO_MENU + '&' + TAG_NOTIFY_ID + '=' + notifyID);
+        } catch (URISyntaxException e) {
+            LOGGER.atWarn().setCause(e).addArgument(TAG_NOTIFY_ID).addArgument(msg.topic).log("could not append {} to {}");
+            return;
+        }
+        subscriptionCache.put(notifyID, msg);
+        final String notifyPath = prefixPath(msg.topic.getPath());
+        final Queue<SseClient> clients = RestServer.getEventClients(notifyPath);
+        final Predicate<SseClient> filter = c -> {
+            final String clientPath = StringUtils.stripEnd(c.ctx.path(), "/");
+            return clientPath.length() >= notifyPath.length() && clientPath.startsWith(notifyPath);
+        };
+        final String topicString = msg.topic.toString();
+        clients.stream().filter(filter).forEach(s -> s.sendEvent(topicString));
     }
 
     @NotNull
@@ -434,25 +447,6 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
             requestQueue.notifyAll();
         }
         return reply;
-    }
-
-    protected void notifySubscribedClients(final @NotNull MdpMessage msg) {
-        final long notifyID = NOTIFY_COUNTER.getAndIncrement();
-        try {
-            msg.topic = QueryParameterParser.appendQueryParameter(msg.topic, TAG_NO_MENU + '&' + TAG_NOTIFY_ID + '=' + notifyID);
-        } catch (URISyntaxException e) {
-            LOGGER.atWarn().setCause(e).addArgument(TAG_NOTIFY_ID).addArgument(msg.topic).log("could not append {} to {}");
-            return;
-        }
-        subscriptionCache.put(notifyID, msg);
-        final String notifyPath = prefixPath(msg.topic.getPath());
-        final Queue<SseClient> clients = RestServer.getEventClients(notifyPath);
-        final Predicate<SseClient> filter = c -> {
-            final String clientPath = StringUtils.stripEnd(c.ctx.path(), "/");
-            return clientPath.length() >= notifyPath.length() && clientPath.startsWith(notifyPath);
-        };
-        final String topicString = msg.topic.toString();
-        clients.stream().filter(filter).forEach(s -> s.sendEvent(topicString));
     }
 
     private Handler getDefaultServiceRestHandler(final String restHandler) { // NOSONAR NOPMD - complexity is acceptable
@@ -531,7 +525,7 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
                     break;
                 }
 
-            } catch (Exception e) { // NOPMD - exception is rethrown
+            } catch (Exception e) { // NOSONAR NOPMD - exception is rethrown
                 throwHtmlException(restHandler, restCtx, service, acceptMimeType, e);
             }
         }, newSseClientHandler);
@@ -582,5 +576,19 @@ public class MajordomoRestPlugin extends BasicMdpWorker {
         }
 
         return JsonStream.serialize(requestMap).getBytes(UTF_8);
+    }
+
+    protected static OpenCmwProtocol.Command getCommand(@NotNull final Context restCtx) {
+        switch (restCtx.method()) {
+        case "GET":
+            return GET_REQUEST;
+        case "POST":
+            return SET_REQUEST;
+        default:
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.atWarn().addArgument(restCtx.req).log("unknown request: {}");
+            }
+            return UNKNOWN;
+        }
     }
 }

--- a/server-rest/src/main/java/io/opencmw/server/rest/RestServer.java
+++ b/server-rest/src/main/java/io/opencmw/server/rest/RestServer.java
@@ -270,6 +270,7 @@ public final class RestServer { // NOPMD -- nomen est omen
                               config.registerPlugin(new OpenApiPlugin(getOpenApiOptions()));
                           })
                            .events(event -> event.handlerAdded(ENDPOINT_ADDED_HANDLER));
+        instance.events(event -> event.serverStopping(() -> instance = null)); // do not reuse stopped Javalin server
         instance.start();
 
         // add login management
@@ -375,7 +376,7 @@ public final class RestServer { // NOPMD -- nomen est omen
         KeyStore keyStore = null;
 
         // read keyStore password
-        try (BufferedReader br = RestServerSettings.REST_KEY_STORE_PASSWORD.isBlank() ? new BufferedReader(new InputStreamReader(RestServer.class.getResourceAsStream("/keystore.pwd"), UTF_8)) //
+        try (BufferedReader br = RestServerSettings.REST_KEY_STORE_PASSWORD.isBlank() ? new BufferedReader(new InputStreamReader(Objects.requireNonNull(RestServer.class.getResourceAsStream("/keystore.pwd"), "keystore.pwd not found"), UTF_8)) //
                                                                                       : Files.newBufferedReader(Paths.get(RestServerSettings.REST_KEY_STORE_PASSWORD), UTF_8)) {
             keyStorePwd = br.readLine();
         } catch (final IOException e) {

--- a/server-rest/src/test/java/io/opencmw/server/rest/MajordomoRestPluginTests.java
+++ b/server-rest/src/test/java/io/opencmw/server/rest/MajordomoRestPluginTests.java
@@ -72,7 +72,7 @@ class MajordomoRestPluginTests {
     private static ImageService imageService;
 
     @BeforeAll
-    @Timeout(10)
+    @Timeout(20)
     static void init() throws IOException {
         assertEquals(8080, RestServerSettings.DEFAULT_PORT); // this assert is important for the following lines to have effect
         Field.getField(RestServerSettings.class, "DEFAULT_PORT").setInt(null, 8099);
@@ -110,7 +110,7 @@ class MajordomoRestPluginTests {
     }
 
     @AfterAll
-    @Timeout(10)
+    @Timeout(20)
     static void finish() {
         helloWorldService.stopWorker();
         imageService.stopWorker();

--- a/server-rest/src/test/java/io/opencmw/server/rest/samples/SystemPropertiesExample.java
+++ b/server-rest/src/test/java/io/opencmw/server/rest/samples/SystemPropertiesExample.java
@@ -1,0 +1,28 @@
+package io.opencmw.server.rest.samples;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opencmw.utils.SystemProperties;
+
+/**
+ * Small usage example for SystemProperties command line interface
+ * call with e.g. '--OpenCmwConstants.DNS_TIMEOUT=2' or '-h' or '--help' for help
+ */
+public class SystemPropertiesExample {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemPropertiesExample.class);
+
+    public static void main(String[] argv) {
+        if (argv.length == 0) {
+            SystemProperties.parseOptions(new String[] { "-h" });
+        }
+        final Map<String, Object> cmdLineValues = SystemProperties.parseOptions(argv);
+        if (!cmdLineValues.isEmpty()) {
+            LOGGER.atInfo().addArgument(cmdLineValues).log("cmd line values set: {}");
+        }
+
+        LOGGER.atInfo().log("main finished");
+    }
+}


### PR DESCRIPTION
* Bumped sundry library versions:
  * fastjson from 1.2.75 to 1.2.76
  * jackson-databind from 2.12.2 to 2.12.3
  * oshi-core from 5.7.0 to 5.7.4
  * disruptor from 3.4.2 to 3.4.4
  * jacoco-maven-plugin from 0.8.6 to 0.8.7
  * version.micrometer from 1.6.5 to 1.6.6

* fixed and added command-line parameter example
