### PR TITLE
bumped additional versions of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,19 +29,19 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.slf4j>2.0.0-alpha0</version.slf4j>
-        <version.auto-service>1.0-rc7</version.auto-service>
-        <version.jetbrains.annotations>20.1.0</version.jetbrains.annotations>
+        <version.auto-service>1.0</version.auto-service>
+        <version.jetbrains.annotations>21.0.1</version.jetbrains.annotations>
         <version.jeromq>0.5.2</version.jeromq>
         <versions.lmax.disruptor>3.4.4</versions.lmax.disruptor>
         <version.javalin>3.13.8</version.javalin>
         <version.jetty>9.4.42.v20210604</version.jetty> <!-- N.B. needs to be synchronised/tested with Javalin version -->
         <version.jsoniter>0.9.23</version.jsoniter>
         <version.fastutil>8.5.4</version.fastutil>
-        <version.javassist>3.27.0-GA</version.javassist>
+        <version.javassist>3.28.0-GA</version.javassist>
         <version.okHttp3>4.9.1</version.okHttp3>
         <version.commons-lang3>3.12.0</version.commons-lang3>
-        <version.jupiter>5.7.1</version.jupiter>
-        <version.awaitility>4.0.3</version.awaitility>
+        <version.jupiter>5.7.2</version.jupiter>
+        <version.awaitility>4.1.0</version.awaitility>
         <version.JMemoryBuddy>0.5.1</version.JMemoryBuddy>
         <version.jmh>1.32</version.jmh>
         <version.micrometer>1.7.1</version.micrometer>
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/serialiser/pom.xml
+++ b/serialiser/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.flatbuffers</groupId>
             <artifactId>flatbuffers-java</artifactId>
-            <version>1.12.0</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* flatbuffers-java from 1.12.0 to 2.0.2
* javassist from 3.27.0-GA to 3.28.0-GA
* version.jupiter from 5.7.1 to 5.7.2
* annotations from 20.1.0 to 21.0.1
* gson from 2.8.6 to 2.8.7
* maven-javadoc-plugin from 3.2.0 to 3.3.0
* awaitility from 4.0.3 to 4.1.0
* auto-service-annotations from 1.0-rc7 to 1.0