### PR TITLE
Allow clipboard data on the top level of the struture

### DIFF
--- a/core/src/main/java/io/opencmw/EventStore.java
+++ b/core/src/main/java/io/opencmw/EventStore.java
@@ -185,10 +185,10 @@ public class EventStore {
 
         assert handlerGroup != null;
         @SuppressWarnings("unchecked")
-        EventHandler<RingBufferEvent>[] eventHanders = allEventHandlers.toArray(new EventHandler[0]);
+        EventHandler<RingBufferEvent>[] eventHandlers = allEventHandlers.toArray(new EventHandler[0]);
         if (startReaper) {
             // start the reaper thread for this given ring buffer
-            disruptor.after(eventHanders).then(new RingBufferEvent.ClearEventHandler());
+            disruptor.after(eventHandlers).then(new RingBufferEvent.ClearEventHandler());
         }
 
         // register this event store to all DefaultHistoryEventHandler

--- a/server/src/main/java/io/opencmw/server/ClipboardWorker.java
+++ b/server/src/main/java/io/opencmw/server/ClipboardWorker.java
@@ -106,14 +106,14 @@ public class ClipboardWorker extends MajordomoWorker<BasicCtx, BinaryData, Binar
 
         final Set<String> subCategories = //
                 repository.keySet().stream() //
-                        .filter(s -> s.startsWith('/' + categoryName))
+                        .filter(s -> StringUtils.substringBeforeLast(s, "/").startsWith('/' + categoryName))
                         .map(s -> StringUtils.removeStart(s, '/' + categoryName))
                         .map(s -> StringUtils.substringBefore(StringUtils.strip(StringUtils.substringBeforeLast(s, "/"), "/"), "/"))
                         .collect(Collectors.toSet());
 
         final List<DataContainer> dataInSubCategory = //
                 repository.entrySet().stream() //
-                        .filter(e -> StringUtils.substringBeforeLast(e.getKey(), "/").equals('/' + categoryName))
+                        .filter(e -> StringUtils.prependIfMissing(StringUtils.substringBeforeLast(e.getKey(), "/"), "/").equals('/' + categoryName))
                         .sorted(Comparator.comparing(s -> s.getValue().getFileName()))
                         .map(Map.Entry::getValue)
                         .collect(Collectors.toList());


### PR DESCRIPTION
The clipboard plugin logic for determining whether a path is a resource or a category did not work for resources on the top level, which where falsely treated as categories, which led to not displaying the thumbnail and generating an invalid category link.