### PR TITLE
Bump dependencies

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>5.8.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.slf4j>2.0.0-alpha2</version.slf4j>
+        <version.slf4j>2.0.0-alpha5</version.slf4j>
         <version.auto-service>1.0</version.auto-service>
-        <version.jetbrains.annotations>21.0.1</version.jetbrains.annotations>
+        <version.jetbrains.annotations>22.0.0</version.jetbrains.annotations>
         <version.jeromq>0.5.2</version.jeromq>
         <versions.lmax.disruptor>3.4.4</versions.lmax.disruptor>
-        <version.javalin>3.13.10</version.javalin>
+        <version.javalin>3.13.11</version.javalin>
         <version.jetty>9.4.43.v20210629</version.jetty> <!-- N.B. needs to be synchronised/tested with Javalin version -->
         <version.jsoniter>0.9.23</version.jsoniter>
         <version.fastutil>8.5.4</version.fastutil>
@@ -43,8 +43,8 @@
         <version.jupiter>5.7.2</version.jupiter>
         <version.awaitility>4.1.0</version.awaitility>
         <version.JMemoryBuddy>0.5.1</version.JMemoryBuddy>
-        <version.jmh>1.32</version.jmh>
-        <version.micrometer>1.7.2</version.micrometer>
+        <version.jmh>1.33</version.jmh>
+        <version.micrometer>1.7.4</version.micrometer>
         <version.velocity>2.3</version.velocity>
         <version.chartfx>11.2.5</version.chartfx>
         <version.docopt>0.6.0.20150202</version.docopt>

--- a/serialiser/pom.xml
+++ b/serialiser/pom.xml
@@ -44,25 +44,25 @@
         <dependency>
             <groupId>com.google.flatbuffers</groupId>
             <artifactId>flatbuffers-java</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.4</version>
+            <version>2.12.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.8.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.76</version>
+            <version>1.2.78</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bump annotations from 21.0.1 to 22.0.0
Bumps [gson](https://github.com/google/gson) from 2.8.7 to 2.8.8.
Bumps `version.javalin` from 3.13.10 to 3.13.11.
Bumps [jackson-databind](https://github.com/FasterXML/jackson) from 2.12.4 to 2.12.5.
Bump version.slf4j from 2.0.0-alpha2 to 2.0.0-alpha5
Bumps `version.slf4j` from 2.0.0-alpha2 to 2.0.0-alpha5.
Bumps [flatbuffers-java](https://github.com/google/flatbuffers) from 2.0.2 to 2.0.3.
Bumps [oshi-core](https://github.com/oshi/oshi) from 5.8.0 to 5.8.2.
Bumps [micrometer-core](https://github.com/micrometer-metrics/micrometer) from 1.7.2 to 1.7.4.
Bumps [fastjson](https://github.com/alibaba/fastjson) from 1.2.76 to 1.2.78.