### PR TITLE
CI: restore maven central deployment

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -105,13 +105,13 @@ jobs:
         with:
           java-version: ${{ env.JAVA_REFERENCE_VERSION }}
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: SONATYPE_USER
           server-password: SONATYPE_PASS
           # gpg-private-key: ${{ secrets.GPG_KEY }} # gpg key was already added in the first java-setup phase, will fail the cleanup if added again
           gpg-passphrase: GPG_PASS
       - name: Deploy to Maven Central
-        run: mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} -Drelease=ossrh deploy
+        run: mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} -Drelease=central deploy
         env:
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}

--- a/pom.xml
+++ b/pom.xml
@@ -339,11 +339,11 @@
             </distributionManagement>
         </profile>
         <profile>
-            <id>releaseOSSRH</id>
+            <id>releaseCentral</id>
             <activation>
                 <property>
                     <name>release</name>
-                    <value>ossrh</value>
+                    <value>central</value>
                 </property>
             </activation>
             <build>
@@ -370,24 +370,17 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Maven Central switched their deployment infrastructure from OSSRH to a maven central infrastrucutre, which requires using a different maven plugin for deployment.

https://central.sonatype.org/pages/ossrh-eol/

The releases can now be viewed and managed (after login) here: https://central.sonatype.com/publishing/namespaces