### PR TITLE
Fix Maven Central Deployment

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -75,8 +75,6 @@ jobs:
       - uses: actions/checkout@v6
       - id: version
         uses: ./.github/actions/get-version
-        with:
-          versionPattern: '${{ env.JAVA_REFERENCE_VERSION }}.[0-9]*.[0-9]*'
       - name: Fetch tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Cache the Maven packages to speed up build
@@ -100,7 +98,7 @@ jobs:
           REVISION: ${{ steps.version.outputs.revision }}
           SHA1: ${{ steps.version.outputs.sha1 }}
           CHANGELIST: ${{ steps.version.outputs.changelist }}
-      - name: Set up JDK to publish to OSSRH
+      - name: Set up JDK to publish to maven central
         uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_REFERENCE_VERSION }}
@@ -110,6 +108,8 @@ jobs:
           server-password: SONATYPE_PASS
           # gpg-private-key: ${{ secrets.GPG_KEY }} # gpg key was already added in the first java-setup phase, will fail the cleanup if added again
           gpg-passphrase: GPG_PASS
+      - name: Print contents of ~/.m2/settings.xml
+        run: cat ~/.m2/settings.xml
       - name: Deploy to Maven Central
         run: mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dsha1=${SHA1} -Dchangelist=${CHANGELIST} -Drelease=central deploy
         env:

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>client</artifactId>
+    <name>opencmw-client</name>
 
     <description>
         OpenCmw, CmwLight, and RESTful client implementations.

--- a/concepts/pom.xml
+++ b/concepts/pom.xml
@@ -11,6 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>concepts</artifactId>
+    <name>opencmw-concepts</name>
     <description>
         Module for experimental features which will be moved to more appropriate modules once they become stable.
     </description>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>core</artifactId>
+    <name>opencmw-core</name>
 
     <description>
         ZeroMQ and REST-based micro-service implementation.

--- a/serialiser/pom.xml
+++ b/serialiser/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>serialiser</artifactId>
+    <name>opencmw-serialiser</name>
 
     <description>
         Efficient reflection based serialisers.

--- a/server-rest/pom.xml
+++ b/server-rest/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <artifactId>server-rest</artifactId>
+    <name>opencmw-server-rest</name>
 
     <description>
         OpenCMW RESTful plugin extension to micro-service implementation.

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>server</artifactId>
+    <name>opencmw-server</name>
 
     <description>
         ZeroMQ and REST-based micro-service server implementation.


### PR DESCRIPTION
The new maven central does a bit more strict checking which requires the modules to have a `<name>` attribute.

Also for some reason the upload step is not triggered, debugging this by adding verbose parameter to the `mvn deploy` and printing the maven settings file.