### PR TITLE
Improve handling of Client Reply Context and SET requests

### DIFF
--- a/.github/actions/get-version/version.sh
+++ b/.github/actions/get-version/version.sh
@@ -25,8 +25,8 @@ else
   export sha1=-$(git rev-parse --short HEAD)
   export changelist="-SNAPSHOT"
 fi
-echo "::set-output name=revision::$rev"
-echo "::set-output name=sha1::$sha1"
-echo "::set-output name=changelist::$changelist"
+echo "revision=$rev" >> "$GITHUB_OUTPUT"
+echo "sha1=$sha1" >> "$GITHUB_OUTPUT"
+echo "changelist=$changelist" >> "$GITHUB_OUTPUT"
 echo "Version will be:"
 echo "${rev}${sha1}${changelist}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,8 +32,6 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - id: version
       uses: ./.github/actions/get-version
-      with:
-          versionPattern: '${{ env.JAVA_REFERENCE_VERSION }}.[0-9]*.[0-9]*'
     - uses: actions/cache@v4 # cache maven packages to speed up build
       with:
         path: ~/.m2

--- a/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
+++ b/client/src/main/java/io/opencmw/client/DataSourcePublisher.java
@@ -526,6 +526,8 @@ public class DataSourcePublisher implements Runnable, AutoCloseable, Closeable {
             msg.add(endpoint.toString());
             if (requestBody == null) {
                 msg.add(EMPTY_ZFRAME);
+            } else if (requestBody instanceof BinaryData binaryData) {
+                msg.add(Arrays.copyOfRange(binaryData.data, 0, binaryData.dataSize > 0 ? binaryData.dataSize : binaryData.data.length));
             } else {
                 final Class<? extends IoSerialiser> matchingSerialiser = DataSource.getFactory(endpoint).getMatchingSerialiserType(endpoint);
                 final IoClassSerialiser serialiser = getSerialiser(); // lazily initialize IoClassSerialiser

--- a/core/src/main/java/io/opencmw/utils/CustomFuture.java
+++ b/core/src/main/java/io/opencmw/utils/CustomFuture.java
@@ -92,18 +92,18 @@ public class CustomFuture<T> implements Future<T> {
      * @throws IllegalStateException in case this method has been already called or Future has been cancelled
      */
     public void setReply(final T newValue) {
+        this.reply = newValue;
         if (done.getAndSet(true)) {
             throw new IllegalStateException("future is not running anymore (either cancelled or already notified)");
         }
-        this.reply = newValue;
         notifyListener();
     }
 
     public void setException(final Throwable exception) {
+        this.exception = exception;
         if (done.getAndSet(true)) {
             throw new IllegalStateException("future is not running anymore (either cancelled or already notified)");
         }
-        this.exception = exception;
         notifyListener();
     }
 

--- a/server/src/main/java/io/opencmw/server/MajordomoWorker.java
+++ b/server/src/main/java/io/opencmw/server/MajordomoWorker.java
@@ -214,9 +214,7 @@ public class MajordomoWorker<C, I, O> extends BasicMdpWorker {
             final URI reqTopic = rawCtx.req.topic;
             rawCtx.rep.topic = new URI(reqTopic.getScheme(), reqTopic.getAuthority(), reqTopic.getPath(), replyQuery, reqTopic.getFragment());
         } else {
-            final String oldQuery = rawCtx.rep.topic.getQuery();
-            final String newQuery = oldQuery == null || oldQuery.isBlank() ? replyQuery : (oldQuery + "&" + replyQuery);
-            rawCtx.rep.topic = new URI(rawCtx.rep.topic.getScheme(), rawCtx.rep.topic.getAuthority(), rawCtx.rep.topic.getPath(), newQuery, null);
+            rawCtx.rep.topic = new URI(rawCtx.rep.topic.getScheme(), rawCtx.rep.topic.getAuthority(), rawCtx.rep.topic.getPath(), replyQuery, null);
         }
         final MimeType replyMimeType = QueryParameterParser.getMimeType(replyQuery);
         // no MIME type given -> stick with the one specified in the request (if it exists) or keep default: copy of raw binary data


### PR DESCRIPTION
The Client was missing a way of communicating the reply context back to the caller for synchronous get requests, instead returning the request context. This led to missing information and was inconsistent with the async get and subscriptions, where the actual reply context was used.

For async get and subscriptions, the code for returning the context only worked for actual context objects, but was broken if the Context type was unspecified, in which case a map will be returned.

Also in the Future there was a (small) chance of a race condition, that was never observed, but from a logic standpoint, the atomic flag should only be set after the result object has been set.

Finally in the Worker, the replyContext caused lots of duplicate entries because it appended all fields from the request AND the reply context instead of just the reply context.

For set requests it was also not possible to pass arbitrary Objects by passing `BinaryData` the same way it is possible for GET.

In the CI this also fixes a few warnings.