### PR TITLE
serialiser: tiered growth in FastByteBuffer.ensureCapacity

### DIFF
--- a/serialiser/src/main/java/io/opencmw/serialiser/spi/FastByteBuffer.java
+++ b/serialiser/src/main/java/io/opencmw/serialiser/spi/FastByteBuffer.java
@@ -50,6 +50,9 @@ public class FastByteBuffer implements IoBuffer {
     private static final int DEFAULT_INITIAL_CAPACITY = 1 << 10;
     private static final int DEFAULT_MIN_CAPACITY_INCREASE = 1 << 10;
     private static final int DEFAULT_MAX_CAPACITY_INCREASE = 100 * (1 << 10);
+    private static final int SMALL_BUFFER_THRESHOLD = 1 << 13; // 8 KiB: below this, double (with min floor)
+    private static final int LARGE_BUFFER_THRESHOLD = 1 << 23; // 8 MiB: at/above this, use multiplicative-capped growth
+    private static final int LARGE_BUFFER_MAX_INCREASE = 1 << 24; // 16 MiB cap on a single grow step
     private static final Unsafe unsafe; // NOPMD
     static {
         // get an instance of the otherwise private 'Unsafe' class
@@ -179,8 +182,18 @@ public class FastByteBuffer implements IoBuffer {
         if (!autoResize) {
             throw new IndexOutOfBoundsException("required capacity: " + newCapacity + " out of bounds: " + capacity() + " and autoResize is disabled");
         }
-        // TODO: add smarter enlarging algorithm (ie. increase fast for small arrays, + n% for medium sized arrays, byte-by-byte for large arrays)
-        final int addCapacity = Math.min(Math.max(DEFAULT_MIN_CAPACITY_INCREASE, newCapacity >> 3), DEFAULT_MAX_CAPACITY_INCREASE); // min, +12.5%, max
+        // tiered growth: avoid O(n^2) reallocation cost at both ends of the size spectrum
+        //  - small   (<  8 KiB): double (with absolute 1 KiB floor) -- amortise repeated grows from tiny initial sizes
+        //  - medium  (<  8 MiB): +12.5%                              -- unchanged, well-balanced for typical message sizes
+        //  - large   (>= 8 MiB): +50% capped at 16 MiB               -- multiplicative growth to avoid the previous linear regime
+        final int addCapacity;
+        if (newCapacity < SMALL_BUFFER_THRESHOLD) {
+            addCapacity = Math.max(DEFAULT_MIN_CAPACITY_INCREASE, newCapacity);
+        } else if (newCapacity < LARGE_BUFFER_THRESHOLD) {
+            addCapacity = newCapacity >> 3;
+        } else {
+            addCapacity = Math.min(newCapacity >> 1, LARGE_BUFFER_MAX_INCREASE);
+        }
         // if we are reading, limit() marks valid data, when writing, position() marks end of valid data, limit() is safe bet because position <= limit
         forceCapacity(newCapacity + addCapacity, limit());
     }

--- a/serialiser/src/test/java/io/opencmw/serialiser/spi/IoBufferTests.java
+++ b/serialiser/src/test/java/io/opencmw/serialiser/spi/IoBufferTests.java
@@ -466,6 +466,41 @@ class IoBufferTests {
     }
 
     @Test
+    void testFastByteBufferGrowSmallTier() {
+        // below 1 KiB floor: grow by the floor (preserves prior behaviour for tiny buffers)
+        final FastByteBuffer tiny = new FastByteBuffer(100, true, null);
+        tiny.ensureCapacity(200);
+        assertEquals(200 + 1024, tiny.capacity(), "small tier (< floor) should add the 1 KiB floor");
+
+        // between floor (1 KiB) and small threshold (8 KiB): double
+        final FastByteBuffer small = new FastByteBuffer(2048, true, null);
+        small.ensureCapacity(3000);
+        assertEquals(3000 + 3000, small.capacity(), "small tier (> floor) should double");
+    }
+
+    @Test
+    void testFastByteBufferGrowMediumTier() {
+        // medium tier (8 KiB .. 8 MiB): +12.5% (unchanged from previous policy)
+        final FastByteBuffer buffer = new FastByteBuffer(16 * 1024, true, null);
+        buffer.ensureCapacity(20 * 1024);
+        final int expectedAdd = (20 * 1024) >> 3; // 2560
+        assertEquals(20 * 1024 + expectedAdd, buffer.capacity(), "medium tier should add +12.5%");
+    }
+
+    @Test
+    void testFastByteBufferGrowLargeTier() {
+        // large tier (>= 8 MiB): +50% capped at 16 MiB.
+        // Under the previous policy, addCapacity was clamped to 100 KiB here,
+        // which produced linear (O(n^2)) growth for large buffers.
+        final int eightMiB = 8 * 1024 * 1024;
+        final FastByteBuffer buffer = new FastByteBuffer(eightMiB, true, null);
+        buffer.ensureCapacity(eightMiB + 1);
+        final int expectedAdd = (eightMiB + 1) >> 1; // ~4 MiB, well under the 16 MiB cap
+        assertEquals(eightMiB + 1 + expectedAdd, buffer.capacity(), "large tier should add +50% (multiplicative)");
+        assertThat("large-tier grow must exceed the previous 100 KiB cap", buffer.capacity() - (eightMiB + 1), Matchers.greaterThan(100 * 1024));
+    }
+
+    @Test
     void testFastByteBufferOutOfBounds() {
         final FastByteBuffer buffer = FastByteBuffer.wrap(new byte[50]);
         // test single getters


### PR DESCRIPTION
Replace the single +12.5% / clamp(1 KiB, 100 KiB) policy with three regimes:
 - small  (<  8 KiB): double, with 1 KiB floor preserved
 - medium (<  8 MiB): +12.5% (unchanged from prior policy)
 - large  (>= 8 MiB): +50% capped at 16 MiB

Previously, the 100 KiB max-add clamp turned large-buffer growth into a linear (O(n^2)) regime: a 10 MiB buffer doubling needed ~100 reallocs. Multiplicative-capped growth bounds this to a logarithmic number of reallocs while keeping single-step memory waste below 16 MiB.

The small-tier 1 KiB floor preserves the cache-reuse behaviour exercised by the existing testFastByteBufferResizing test.